### PR TITLE
Enhance MockValidatorService with advanced schema and record validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
@@ -101,6 +102,13 @@
 			<version>1.5.5.Final</version>
 		</dependency>
 
+        <!-- Email validator -->
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.9.0</version>
+        </dependency>
+
 		<!-- MapStruct processor (annotation processing) -->
 		<dependency>
 			<groupId>org.mapstruct</groupId>
@@ -151,6 +159,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
+
 
     </dependencies>
 

--- a/src/main/java/com/mockify/backend/service/impl/MockValidatorServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockValidatorServiceImpl.java
@@ -44,7 +44,7 @@ public class MockValidatorServiceImpl implements MockValidatorService {
                     return type;
                 }
             }
-            throw new IllegalArgumentException("Invalid schema type: " + value);
+            throw new BadRequestException("Invalid schema type: " + value);
         }
     }
 

--- a/src/main/java/com/mockify/backend/service/impl/MockValidatorServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockValidatorServiceImpl.java
@@ -2,11 +2,12 @@ package com.mockify.backend.service.impl;
 
 import com.mockify.backend.exception.BadRequestException;
 import com.mockify.backend.service.MockValidatorService;
+import org.apache.commons.validator.routines.EmailValidator;
 import org.springframework.stereotype.Service;
 
 import java.time.OffsetDateTime;
 import java.util.*;
-import java.util.regex.Pattern;
+
 
 @Service
 public class MockValidatorServiceImpl implements MockValidatorService {
@@ -17,13 +18,36 @@ public class MockValidatorServiceImpl implements MockValidatorService {
      * This keeps the system strict and prevents users from defining random or unsafe types.
      */
 
-    private static final Set<String> ALLOWED_TYPES = Set.of(
-            "string", "number", "boolean", "array", "object",
-            "email", "uuid", "datetime", "null", "json", "enum"
-    );
+    private enum ALLOWED_TYPES {
 
-    private static final Pattern EMAIL_PATTERN =
-            Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+        STRING("string"),
+        NUMBER("number"),
+        BOOLEAN("boolean"),
+        ARRAY("array"),
+        OBJECT("object"),
+        EMAIL("email"),
+        UUID("uuid"),
+        DATETIME("datetime"),
+        NULL("null"),
+        JSON("json"),
+        ENUM("enum");
+
+        private final String value;
+
+        ALLOWED_TYPES(String value) {
+            this.value = value;
+        }
+
+        public static ALLOWED_TYPES from(String value) {
+            for (ALLOWED_TYPES type : values()) {
+                if (type.value.equalsIgnoreCase(value)) {
+                    return type;
+                }
+            }
+            throw new IllegalArgumentException("Invalid schema type: " + value);
+        }
+    }
+
 
     // validateSchemaDefinition
 
@@ -43,34 +67,28 @@ public class MockValidatorServiceImpl implements MockValidatorService {
                 throw new BadRequestException("Schema field name cannot be empty");
             }
 
-            String type;
+            ALLOWED_TYPES type;
 
 
             if (definition instanceof String strType) {
-                type = strType.toLowerCase();
-            }
-            else if (definition instanceof Map<?, ?> defMap) {
+                type = parseType(field, strType);
+            } else if (definition instanceof Map<?, ?> defMap) {
 
                 Object typeObj = defMap.get("type");
                 if (!(typeObj instanceof String)) {
                     throw new BadRequestException("Field '" + field + "' must define a type");
                 }
 
-                type = typeObj.toString().toLowerCase();
+                type = parseType(field, typeObj.toString());
 
-                if ("enum".equals(type)) {
+                if (type == ALLOWED_TYPES.ENUM) {
                     Object values = defMap.get("values");
                     if (!(values instanceof List<?> list) || list.isEmpty()) {
                         throw new BadRequestException("Enum field '" + field + "' must define non-empty values");
                     }
                 }
-            }
-            else {
+            } else {
                 throw new BadRequestException("Invalid schema format for field '" + field + "'");
-            }
-
-            if (!ALLOWED_TYPES.contains(type)) {
-                throw new BadRequestException("Invalid type for field '" + field + "'. Allowed: " + ALLOWED_TYPES);
             }
         }
     }
@@ -101,20 +119,34 @@ public class MockValidatorServiceImpl implements MockValidatorService {
 
             Object value = recordJson.get(field);
 
-            String type;
+            ALLOWED_TYPES type;
             List<?> enumValues = null;
 
             if (schemaDef instanceof String strType) {
-                type = strType.toLowerCase();
-            }
-            else if (schemaDef instanceof Map<?, ?> defMap) {
-                type = defMap.get("type").toString().toLowerCase();
+                type = parseType(field, strType);
+            } else if (schemaDef instanceof Map<?, ?> defMap) {
 
-                if ("enum".equals(type)) {
+                Object typeObj = defMap.get("type");
+
+                if (typeObj == null) {
+                    throw new BadRequestException(
+                            "Field '" + field + "' schema must define a 'type' property"
+                    );
+                }
+
+                if (!(typeObj instanceof String)) {
+                    throw new BadRequestException(
+                            "Field '" + field + "' schema 'type' must be a string"
+                    );
+                }
+
+                type = parseType(field, (String) typeObj);
+
+
+                if (type == ALLOWED_TYPES.ENUM) {
                     enumValues = (List<?>) defMap.get("values");
                 }
-            }
-            else {
+            } else {
                 throw new BadRequestException("Invalid schema definition for field '" + field + "'");
             }
 
@@ -132,9 +164,9 @@ public class MockValidatorServiceImpl implements MockValidatorService {
 
     // validateValueByType
 
-    private void validateValueByType(String field, String type, Object value, List<?> enumValues) {
+    private void validateValueByType(String field, ALLOWED_TYPES type, Object value, List<?> enumValues) {
 
-        if ("null".equals(type)) {
+        if (type == ALLOWED_TYPES.NULL) {
             if (value != null) {
                 throw new BadRequestException("Field '" + field + "' must be null");
             }
@@ -147,56 +179,75 @@ public class MockValidatorServiceImpl implements MockValidatorService {
 
         switch (type) {
 
-            case "string" -> require(value instanceof String, field, "string");
+            case STRING:
+                require(value instanceof String, field, "string");
+                break;
 
-            case "number" -> require(value instanceof Number, field, "number");
+            case NUMBER:
+                require(value instanceof Number, field, "number");
+                break;
 
-            case "boolean" -> require(value instanceof Boolean, field, "boolean");
+            case BOOLEAN:
+                require(value instanceof Boolean, field, "boolean");
+                break;
 
-            case "array" -> require(value instanceof List<?>, field, "array");
+            case ARRAY:
+                require(value instanceof List<?>, field, "array");
+                break;
 
-            case "object", "json" -> require(value instanceof Map<?, ?>, field, "object");
+            case OBJECT:
+            case JSON:
+                require(value instanceof Map<?, ?>, field, "object");
+                break;
 
-            case "email" -> {
+            case EMAIL:
                 require(value instanceof String, field, "email");
-                if (!EMAIL_PATTERN.matcher(value.toString()).matches()) {
+                if (!EmailValidator.getInstance().isValid(value.toString())) {
                     throw new BadRequestException("Invalid email format for field '" + field + "'");
                 }
-            }
+                break;
 
-            case "uuid" -> {
+            case UUID:
                 require(value instanceof String, field, "uuid");
                 try {
                     UUID.fromString(value.toString());
                 } catch (Exception e) {
                     throw new BadRequestException("Invalid UUID format for field '" + field + "'");
                 }
-            }
+                break;
 
-            case "datetime" -> {
+            case DATETIME:
                 require(value instanceof String, field, "datetime");
                 try {
                     OffsetDateTime.parse(value.toString());
                 } catch (Exception e) {
                     throw new BadRequestException("Invalid datetime format (ISO-8601) for field '" + field + "'");
                 }
-            }
+                break;
 
-            case "enum" -> {
+            case ENUM:
                 if (enumValues == null || !enumValues.contains(value)) {
                     throw new BadRequestException(
                             "Invalid enum value for field '" + field + "'. Allowed: " + enumValues
                     );
                 }
-            }
-
-            default -> throw new BadRequestException("Unsupported schema data type: " + type);
+                break;
         }
     }
 
     private void require(boolean condition, String field, String type) {
         if (!condition) {
             throw new BadRequestException("Field '" + field + "' must be of type " + type);
+        }
+    }
+
+    // Helper (internal only)
+
+    private ALLOWED_TYPES parseType(String field, String typeStr) {
+        try {
+            return ALLOWED_TYPES.from(typeStr);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("Invalid type for field '" + field + "': " + typeStr);
         }
     }
 }

--- a/src/main/java/com/mockify/backend/service/impl/MockValidatorServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockValidatorServiceImpl.java
@@ -4,18 +4,29 @@ import com.mockify.backend.exception.BadRequestException;
 import com.mockify.backend.service.MockValidatorService;
 import org.springframework.stereotype.Service;
 
-import java.lang.reflect.Array;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.regex.Pattern;
 
 @Service
 public class MockValidatorServiceImpl implements MockValidatorService {
 
-    private static final Set<String> ALLOWED_TYPES =
-            Set.of("string", "number", "boolean", "array", "object");
 
-    // Validate Schema Types
+    /**
+     * All supported data types that a schema field is allowed to use.
+     * This keeps the system strict and prevents users from defining random or unsafe types.
+     */
+
+    private static final Set<String> ALLOWED_TYPES = Set.of(
+            "string", "number", "boolean", "array", "object",
+            "email", "uuid", "datetime", "null", "json", "enum"
+    );
+
+    private static final Pattern EMAIL_PATTERN =
+            Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+
+    // validateSchemaDefinition
+
     @Override
     public void validateSchemaDefinition(Map<String, Object> schemaJson) {
 
@@ -26,30 +37,47 @@ public class MockValidatorServiceImpl implements MockValidatorService {
         for (Map.Entry<String, Object> entry : schemaJson.entrySet()) {
 
             String field = entry.getKey();
-            Object typeValue = entry.getValue();
+            Object definition = entry.getValue();
 
             if (field == null || field.trim().isEmpty()) {
                 throw new BadRequestException("Schema field name cannot be empty");
             }
 
-            if (!(typeValue instanceof String type)) {
-                throw new BadRequestException(
-                        "Invalid schema: Type of field '" + field + "' must be a string"
-                );
+            String type;
+
+
+            if (definition instanceof String strType) {
+                type = strType.toLowerCase();
+            }
+            else if (definition instanceof Map<?, ?> defMap) {
+
+                Object typeObj = defMap.get("type");
+                if (!(typeObj instanceof String)) {
+                    throw new BadRequestException("Field '" + field + "' must define a type");
+                }
+
+                type = typeObj.toString().toLowerCase();
+
+                if ("enum".equals(type)) {
+                    Object values = defMap.get("values");
+                    if (!(values instanceof List<?> list) || list.isEmpty()) {
+                        throw new BadRequestException("Enum field '" + field + "' must define non-empty values");
+                    }
+                }
+            }
+            else {
+                throw new BadRequestException("Invalid schema format for field '" + field + "'");
             }
 
-            String normalized = type.toLowerCase();
-
-            if (!ALLOWED_TYPES.contains(normalized)) {
-                throw new BadRequestException(
-                        "Invalid type for field '" + field + "'. Allowed: " + ALLOWED_TYPES
-                );
+            if (!ALLOWED_TYPES.contains(type)) {
+                throw new BadRequestException("Invalid type for field '" + field + "'. Allowed: " + ALLOWED_TYPES);
             }
         }
     }
 
 
-    // Validate Record JSON
+    // Record Validation
+
     @Override
     public void validateRecordAgainstSchema(
             Map<String, Object> schemaJson,
@@ -60,11 +88,12 @@ public class MockValidatorServiceImpl implements MockValidatorService {
             throw new BadRequestException("Record data cannot be null");
         }
 
-        // Check missing or mismatched fields
+        // Validate each field defined in schema
+
         for (Map.Entry<String, Object> entry : schemaJson.entrySet()) {
 
             String field = entry.getKey();
-            String expectedType = entry.getValue().toString().toLowerCase();
+            Object schemaDef = entry.getValue();
 
             if (!recordJson.containsKey(field)) {
                 throw new BadRequestException("Missing field '" + field + "' in record");
@@ -72,42 +101,102 @@ public class MockValidatorServiceImpl implements MockValidatorService {
 
             Object value = recordJson.get(field);
 
-            switch (expectedType) {
-                case "string" -> {
-                    if (!(value instanceof String)) {
-                        throw new BadRequestException("Field '" + field + "' must be a string");
-                    }
-                }
-                case "number" -> {
-                    if (!(value instanceof Number)) {
-                        throw new BadRequestException("Field '" + field + "' must be a number");
-                    }
-                }
-                case "boolean" -> {
-                    if (!(value instanceof Boolean)) {
-                        throw new BadRequestException("Field '" + field + "' must be a boolean");
-                    }
-                }
-                case "array" -> {
-                    if (!(value instanceof List<?> list)) {
-                        throw new BadRequestException("Field '" + field + "' must be an array");
-                    }
-                }
-                case "object" -> {
-                    if (!(value instanceof Map<?, ?> map)) {
-                        throw new BadRequestException("Field '" + field + "' must be an object");
-                    }
-                }
-                default ->
-                        throw new BadRequestException("Unsupported schema data type: " + expectedType);
+            String type;
+            List<?> enumValues = null;
+
+            if (schemaDef instanceof String strType) {
+                type = strType.toLowerCase();
             }
+            else if (schemaDef instanceof Map<?, ?> defMap) {
+                type = defMap.get("type").toString().toLowerCase();
+
+                if ("enum".equals(type)) {
+                    enumValues = (List<?>) defMap.get("values");
+                }
+            }
+            else {
+                throw new BadRequestException("Invalid schema definition for field '" + field + "'");
+            }
+
+            validateValueByType(field, type, value, enumValues);
         }
 
-        // Check for extra fields not in schema
+        // Extra field protection
         for (String field : recordJson.keySet()) {
             if (!schemaJson.containsKey(field)) {
                 throw new BadRequestException("Field '" + field + "' is not allowed in this schema");
             }
+        }
+    }
+
+
+    // validateValueByType
+
+    private void validateValueByType(String field, String type, Object value, List<?> enumValues) {
+
+        if ("null".equals(type)) {
+            if (value != null) {
+                throw new BadRequestException("Field '" + field + "' must be null");
+            }
+            return;
+        }
+
+        if (value == null) {
+            throw new BadRequestException("Field '" + field + "' cannot be null");
+        }
+
+        switch (type) {
+
+            case "string" -> require(value instanceof String, field, "string");
+
+            case "number" -> require(value instanceof Number, field, "number");
+
+            case "boolean" -> require(value instanceof Boolean, field, "boolean");
+
+            case "array" -> require(value instanceof List<?>, field, "array");
+
+            case "object", "json" -> require(value instanceof Map<?, ?>, field, "object");
+
+            case "email" -> {
+                require(value instanceof String, field, "email");
+                if (!EMAIL_PATTERN.matcher(value.toString()).matches()) {
+                    throw new BadRequestException("Invalid email format for field '" + field + "'");
+                }
+            }
+
+            case "uuid" -> {
+                require(value instanceof String, field, "uuid");
+                try {
+                    UUID.fromString(value.toString());
+                } catch (Exception e) {
+                    throw new BadRequestException("Invalid UUID format for field '" + field + "'");
+                }
+            }
+
+            case "datetime" -> {
+                require(value instanceof String, field, "datetime");
+                try {
+                    OffsetDateTime.parse(value.toString());
+                } catch (Exception e) {
+                    throw new BadRequestException("Invalid datetime format (ISO-8601) for field '" + field + "'");
+                }
+            }
+
+            case "enum" -> {
+                if (enumValues == null || !enumValues.contains(value)) {
+                    throw new BadRequestException(
+                            "Invalid enum value for field '" + field + "'. Allowed: " + enumValues
+                    );
+                }
+            }
+
+            default -> throw new BadRequestException("Unsupported schema data type: " + type);
+        }
+    }
+
+    private void require(boolean condition, String field, String type) {
+        if (!condition) {
+            throw new BadRequestException("Field '" + field + "' must be of type " + type);
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR enhances `MockValidatorServiceImpl` to support advanced schema-driven validation for mock records.

It adds strict validation for multiple new data types and improves overall data integrity for both single and bulk record creation.

---

## What's new

### Supported schema types
- string
- number
- boolean
- array
- object
- json
- email (regex validation)
- uuid (UUID format validation)
- datetime (ISO-8601 validation)
- enum (allowed values validation)
- null

---

## Key improvements

- Added centralized type validation engine (`validateValueByType`)
- Added email format validation using regex
- Added UUID format validation
- Added ISO-8601 datetime validation
- Added enum value enforcement
- Added strict null type handling
- Improved schema definition validation
- Prevented extra fields in record payloads
- Fully compatible with bulk record creation (transaction-safe)

---

## Backward compatibility

- Existing schemas using `"field": "string"` format remain supported
- New object-based schema definitions for enums are supported

---

## Example schema

```json
{
  "email": "email",
  "userId": "uuid",
  "status": { "type": "enum", "values": ["ACTIVE", "BLOCKED"] }
}
