### PR TITLE
feat(admin): Add admin role, email verification flag, and admin visibility APIs

### DIFF
--- a/src/main/java/com/mockify/backend/common/enums/UserRole.java
+++ b/src/main/java/com/mockify/backend/common/enums/UserRole.java
@@ -1,0 +1,6 @@
+package com.mockify.backend.common.enums;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/mockify/backend/config/OpenApiConfig.java
+++ b/src/main/java/com/mockify/backend/config/OpenApiConfig.java
@@ -44,11 +44,14 @@ public class OpenApiConfig {
                 .pathsToMatch("/api/**")
                 .packagesToScan("com.mockify.backend.controller")
                 .addOpenApiCustomizer(openApi -> openApi.setTags(List.of(
-                        new Tag().name("Authentication").description("Handles user registration, login, logout, token refresh, and current user retrieval."),
-                        new Tag().name("Organization").description("Manages organization resources."),
-                        new Tag().name("Project").description("Handles project lifecycle operations."),
-                        new Tag().name("Mock Schema").description("Defines schema for mock data."),
-                        new Tag().name("Mock Record").description("Manages mock records based on schemas.")
+                        new Tag().name("Admin").description("Administrative operations for reviewing and managing user observations."),
+                        new Tag().name("Authentication").description("User authentication and authorization operations including registration, login, logout, token refresh, and current user retrieval."),
+                        new Tag().name("Organization").description("Operations for managing organizations and their associated resources."),
+                        new Tag().name("Project").description("Operations for managing the project lifecycle and related resources."),
+                        new Tag().name("Mock Schema").description("Operations for defining and managing mock data schemas."),
+                        new Tag().name("Mock Record").description("Operations for creating, retrieving, updating, and deleting mock records based on defined schemas."),
+                        new Tag().name("Public MockRecord").description("Publicly accessible operations for retrieving mock records."),
+                        new Tag().name("Endpoint").description("Operations for validating and resolving endpoint slugs.")
                 )))
                 .build();
     }

--- a/src/main/java/com/mockify/backend/config/SecurityConfig.java
+++ b/src/main/java/com/mockify/backend/config/SecurityConfig.java
@@ -64,6 +64,10 @@ public class SecurityConfig {
                         .requestMatchers("/api/mock/**").permitAll()
                         .requestMatchers("/api/endpoints/lookup/**").permitAll()
 
+                        // Admin-only endpoints
+                        .requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")
+                        .requestMatchers("/actuator/**").hasAuthority("ROLE_ADMIN")
+
                         // OAuth2 endpoints must be public for the handshake
                         .requestMatchers("/oauth2/**").permitAll()
                         .requestMatchers("/login/oauth2/**").permitAll()
@@ -78,9 +82,8 @@ public class SecurityConfig {
                                 "/webjars/**"
                         ).permitAll()
 
-                        // Allows all Actuator endpoints only for DEV without requiring auth
+                        // Allows some Actuator endpoints only for DEV without requiring auth
                         .requestMatchers("/actuator/health", "/actuator/info").permitAll()
-                        .requestMatchers("/actuator/**").permitAll() // TODO: Set role to ADMIN in prod (Must)
 
                         // All other endpoints require authentication
                         .anyRequest().authenticated()

--- a/src/main/java/com/mockify/backend/controller/AdminController.java
+++ b/src/main/java/com/mockify/backend/controller/AdminController.java
@@ -1,0 +1,63 @@
+package com.mockify.backend.controller;
+
+import com.mockify.backend.dto.response.admin.*;
+import com.mockify.backend.service.AdminService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/admin")
+@Tag(name = "Admin")
+@PreAuthorize("hasAuthority('ROLE_ADMIN')")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    /*
+         Basic admin health endpoint.
+         Used to verify ADMIN access works.
+     */
+    @GetMapping("ping")
+    public Map<String, Object> adminPing(){
+        return Map.of(
+                "status", "ok",
+                "message", "Admin access granted"
+        );
+    }
+
+    // TODO: Add pagination (Page<T>) & filters (?ownerId=)
+
+    @GetMapping("/users")
+    public List<AdminUserResponse> users() {
+        return adminService.listUsers();
+    }
+
+    @GetMapping("/organizations")
+    public List<AdminOrganizationResponse> organizations() {
+        return adminService.listOrganizations();
+    }
+
+    @GetMapping("/projects")
+    public List<AdminProjectResponse> projects() {
+        return adminService.listProjects();
+    }
+
+    @GetMapping("/schemas")
+    public List<AdminMockSchemaResponse> schemas() {
+        return adminService.listSchemas();
+    }
+
+    @GetMapping("/records")
+    public List<AdminMockRecordResponse> records() {
+        return adminService.listRecords();
+    }
+
+    // TODO: Add promote/demote users
+}

--- a/src/main/java/com/mockify/backend/controller/AdminController.java
+++ b/src/main/java/com/mockify/backend/controller/AdminController.java
@@ -24,7 +24,7 @@ public class AdminController {
          Basic admin health endpoint.
          Used to verify ADMIN access works.
      */
-    @GetMapping("ping")
+    @GetMapping("/ping")
     public Map<String, Object> adminPing(){
         return Map.of(
                 "status", "ok",

--- a/src/main/java/com/mockify/backend/controller/AuthController.java
+++ b/src/main/java/com/mockify/backend/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.mockify.backend.controller;
 
 import com.mockify.backend.dto.request.auth.*;
-import com.mockify.backend.dto.response.AuthResult;
+import com.mockify.backend.dto.response.auth.AuthResult;
 import com.mockify.backend.dto.response.auth.AuthResponse;
 import com.mockify.backend.dto.response.auth.UserResponse;
 import com.mockify.backend.security.CookieUtil;

--- a/src/main/java/com/mockify/backend/controller/EndpointController.java
+++ b/src/main/java/com/mockify/backend/controller/EndpointController.java
@@ -1,7 +1,7 @@
 package com.mockify.backend.controller;
 
-import com.mockify.backend.model.Endpoint;
 import com.mockify.backend.repository.EndpointRepository;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +11,7 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/endpoints")
+@Tag(name = "Endpoint")
 public class EndpointController {
 
     private final EndpointRepository endpointRepository;

--- a/src/main/java/com/mockify/backend/controller/PublicMockRecordController.java
+++ b/src/main/java/com/mockify/backend/controller/PublicMockRecordController.java
@@ -3,6 +3,7 @@ package com.mockify.backend.controller;
 import com.mockify.backend.dto.response.record.MockRecordResponse;
 import com.mockify.backend.service.EndpointService;
 import com.mockify.backend.service.PublicMockRecordService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,7 @@ import java.util.UUID;
 @RequestMapping("/api/mock")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "Public MockRecord")
 public class PublicMockRecordController {
 
     private final PublicMockRecordService publicMockRecordService;

--- a/src/main/java/com/mockify/backend/dto/response/admin/AdminMockRecordResponse.java
+++ b/src/main/java/com/mockify/backend/dto/response/admin/AdminMockRecordResponse.java
@@ -1,0 +1,11 @@
+package com.mockify.backend.dto.response.admin;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record AdminMockRecordResponse(
+        UUID id,
+        UUID schemaId,
+        LocalDateTime createdAt,
+        LocalDateTime expiresAt
+) {}

--- a/src/main/java/com/mockify/backend/dto/response/admin/AdminMockSchemaResponse.java
+++ b/src/main/java/com/mockify/backend/dto/response/admin/AdminMockSchemaResponse.java
@@ -1,0 +1,15 @@
+package com.mockify.backend.dto.response.admin;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record AdminMockSchemaResponse(
+        UUID id,
+        String name,
+        String slug,
+        UUID projectId,
+        String projectName,
+        int recordCount,
+        LocalDateTime createdAt
+) {}
+

--- a/src/main/java/com/mockify/backend/dto/response/admin/AdminOrganizationResponse.java
+++ b/src/main/java/com/mockify/backend/dto/response/admin/AdminOrganizationResponse.java
@@ -1,0 +1,15 @@
+package com.mockify.backend.dto.response.admin;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record AdminOrganizationResponse(
+        UUID id,
+        String name,
+        String slug,
+        UUID ownerId,
+        String ownerName,
+        int projectCount,
+        LocalDateTime createdAt
+) {}
+

--- a/src/main/java/com/mockify/backend/dto/response/admin/AdminProjectResponse.java
+++ b/src/main/java/com/mockify/backend/dto/response/admin/AdminProjectResponse.java
@@ -1,0 +1,15 @@
+package com.mockify.backend.dto.response.admin;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record AdminProjectResponse(
+        UUID id,
+        String name,
+        String slug,
+        UUID organizationId,
+        String organizationName,
+        int schemaCount,
+        LocalDateTime createdAt
+) {}
+

--- a/src/main/java/com/mockify/backend/dto/response/admin/AdminUserResponse.java
+++ b/src/main/java/com/mockify/backend/dto/response/admin/AdminUserResponse.java
@@ -1,0 +1,16 @@
+package com.mockify.backend.dto.response.admin;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record AdminUserResponse(
+        UUID id,
+        String name,
+        String email,
+        boolean emailVerified,
+        String role,
+        String providerName,
+        String username,
+        LocalDateTime createdAt
+) {}
+

--- a/src/main/java/com/mockify/backend/dto/response/auth/AuthResult.java
+++ b/src/main/java/com/mockify/backend/dto/response/auth/AuthResult.java
@@ -1,6 +1,5 @@
-package com.mockify.backend.dto.response;
+package com.mockify.backend.dto.response.auth;
 
-import com.mockify.backend.dto.response.auth.AuthResponse;
 import org.springframework.http.ResponseCookie;
 
 public record AuthResult(

--- a/src/main/java/com/mockify/backend/dto/response/auth/TokenPair.java
+++ b/src/main/java/com/mockify/backend/dto/response/auth/TokenPair.java
@@ -1,3 +1,3 @@
-package com.mockify.backend.dto.response;
+package com.mockify.backend.dto.response.auth;
 
 public record TokenPair(String accessToken, String refreshToken) {}

--- a/src/main/java/com/mockify/backend/exception/JwtTokenExpiredException.java
+++ b/src/main/java/com/mockify/backend/exception/JwtTokenExpiredException.java
@@ -1,0 +1,9 @@
+package com.mockify.backend.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class JwtTokenExpiredException extends BaseException {
+    public JwtTokenExpiredException(String message) {
+        super(message, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/mockify/backend/exception/JwtTokenInvalidException.java
+++ b/src/main/java/com/mockify/backend/exception/JwtTokenInvalidException.java
@@ -1,0 +1,9 @@
+package com.mockify.backend.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class JwtTokenInvalidException extends BaseException {
+    public JwtTokenInvalidException(String message) {
+        super(message, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/mockify/backend/mapper/admin/AdminMockRecordMapper.java
+++ b/src/main/java/com/mockify/backend/mapper/admin/AdminMockRecordMapper.java
@@ -1,0 +1,18 @@
+package com.mockify.backend.mapper.admin;
+
+import com.mockify.backend.dto.response.admin.AdminMockRecordResponse;
+import com.mockify.backend.model.MockRecord;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface AdminMockRecordMapper {
+
+    @Mapping(target = "schemaId", source = "mockSchema.id")
+    AdminMockRecordResponse toResponse(MockRecord record);
+
+    List<AdminMockRecordResponse> toResponseList(List<MockRecord> records);
+}
+

--- a/src/main/java/com/mockify/backend/mapper/admin/AdminMockSchemaMapper.java
+++ b/src/main/java/com/mockify/backend/mapper/admin/AdminMockSchemaMapper.java
@@ -1,0 +1,19 @@
+package com.mockify.backend.mapper.admin;
+
+import com.mockify.backend.dto.response.admin.AdminMockSchemaResponse;
+import com.mockify.backend.model.MockSchema;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface AdminMockSchemaMapper {
+
+    @Mapping(target = "projectId", source = "project.id")
+    @Mapping(target = "projectName", source = "project.name")
+    @Mapping(target = "recordCount", expression = "java(schema.getMockRecords().size())")
+    AdminMockSchemaResponse toResponse(MockSchema schema);
+
+    List<AdminMockSchemaResponse> toResponseList(List<MockSchema> schemas);
+}

--- a/src/main/java/com/mockify/backend/mapper/admin/AdminOrganizationMapper.java
+++ b/src/main/java/com/mockify/backend/mapper/admin/AdminOrganizationMapper.java
@@ -1,0 +1,19 @@
+package com.mockify.backend.mapper.admin;
+
+import com.mockify.backend.dto.response.admin.AdminOrganizationResponse;
+import com.mockify.backend.model.Organization;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface AdminOrganizationMapper {
+
+    @Mapping(target = "ownerId", source = "owner.id")
+    @Mapping(target = "ownerName", source = "owner.name")
+    @Mapping(target = "projectCount", expression = "java(organization.getProjects().size())")
+    AdminOrganizationResponse toResponse(Organization organization);
+
+    List<AdminOrganizationResponse> toResponseList(List<Organization> organizations);
+}

--- a/src/main/java/com/mockify/backend/mapper/admin/AdminProjectMapper.java
+++ b/src/main/java/com/mockify/backend/mapper/admin/AdminProjectMapper.java
@@ -1,0 +1,19 @@
+package com.mockify.backend.mapper.admin;
+
+import com.mockify.backend.dto.response.admin.AdminProjectResponse;
+import com.mockify.backend.model.Project;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface AdminProjectMapper {
+
+    @Mapping(target = "organizationId", source = "organization.id")
+    @Mapping(target = "organizationName", source = "organization.name")
+    @Mapping(target = "schemaCount", expression = "java(project.getMockSchemas().size())")
+    AdminProjectResponse toResponse(Project project);
+
+    List<AdminProjectResponse> toResponseList(List<Project> projects);
+}

--- a/src/main/java/com/mockify/backend/mapper/admin/AdminUserMapper.java
+++ b/src/main/java/com/mockify/backend/mapper/admin/AdminUserMapper.java
@@ -1,0 +1,17 @@
+package com.mockify.backend.mapper.admin;
+
+import com.mockify.backend.dto.response.admin.AdminUserResponse;
+import com.mockify.backend.model.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface AdminUserMapper {
+
+    @Mapping(target = "role", source = "role")
+    AdminUserResponse toResponse(User user);
+
+    List<AdminUserResponse> toResponseList(List<User> users);
+}

--- a/src/main/java/com/mockify/backend/model/User.java
+++ b/src/main/java/com/mockify/backend/model/User.java
@@ -1,6 +1,7 @@
 package com.mockify.backend.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.mockify.backend.common.enums.UserRole;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -26,8 +27,16 @@ public class User {
     @Column(nullable = false, unique = true)
     private String email;
 
+    @Column(name = "email_verified", nullable = false)
+    private boolean emailVerified = false;
+
     @Column(name = "password")
     private String password; // Now nullable for OAuth users
+
+    // Default role is USER to prevent accidental admin creation
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole role = UserRole.USER;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/mockify/backend/security/CustomUserDetailsService.java
+++ b/src/main/java/com/mockify/backend/security/CustomUserDetailsService.java
@@ -3,6 +3,8 @@ package com.mockify.backend.security;
 import com.mockify.backend.model.User;
 import com.mockify.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -10,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -32,10 +35,13 @@ public class CustomUserDetailsService implements UserDetailsService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + userId));
 
+        GrantedAuthority authority =
+                new SimpleGrantedAuthority("ROLE_" + user.getRole().name());
+
         return new org.springframework.security.core.userdetails.User(
                 user.getId().toString(),
                 user.getPassword(),
-                Collections.emptyList()
+                Collections.singletonList(authority)
         );
     }
 }

--- a/src/main/java/com/mockify/backend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mockify/backend/security/JwtAuthenticationFilter.java
@@ -75,4 +75,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         return null;
     }
+
+    // Skip JWT filter for public and auth-related endpoints to avoid unnecessary token parsing and interfering with auth flows
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+
+        return path.startsWith("/api/auth/")
+                || path.startsWith("/oauth2/")
+                || path.startsWith("/login/oauth2/");
+    }
 }

--- a/src/main/java/com/mockify/backend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mockify/backend/security/JwtAuthenticationFilter.java
@@ -1,9 +1,12 @@
 package com.mockify.backend.security;
 
+import com.mockify.backend.exception.JwtTokenExpiredException;
+import com.mockify.backend.exception.JwtTokenInvalidException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -15,6 +18,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.UUID;
 
 @Component
@@ -25,64 +29,99 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService userDetailsService;
 
+    private static final String AUTH_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    // Endpoints that bypass JWT authentication
+    private static final Set<String> PUBLIC_ENDPOINTS = Set.of(
+            "/api/auth/register",
+            "/api/auth/register/verify",
+            "/api/auth/login",
+            "/api/auth/refresh",
+            "/api/auth/logout",
+            "/api/auth/forgot-password",
+            "/api/auth/reset-password"
+    );
+
     @Override
     protected void doFilterInternal(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain) throws ServletException, IOException {
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
 
-        try {
-            // Extract JWT token from request
-            String jwt = getJwtFromRequest(request);
-
-            // Validate token and set authentication
-            if (jwt != null && jwtTokenProvider.validateAccessToken(jwt)) {
-                // Get user ID from token
-                UUID userId = jwtTokenProvider.getUserIdFromToken(jwt);
-
-                // Load user details
-                UserDetails userDetails = userDetailsService.loadUserByUsername(String.valueOf(userId));
-
-                // Create authentication token
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(
-                                userDetails,
-                                null,
-                                userDetails.getAuthorities()
-                        );
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
-                // Set authentication in security context
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-
-                log.debug("Set authentication for user: {}", userId);
-            }
-        } catch (Exception ex) {
-            log.error("Could not set user authentication in security context", ex);
+        // Skip authentication if already set by another filter
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            filterChain.doFilter(request, response);
+            return;
         }
 
-        // Continue filter chain
+        // Extract JWT from Authorization header
+        String jwt = getJwtFromRequest(request);
+
+        // If no token is present, continue with remaining filters
+        if (!StringUtils.hasText(jwt)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            // Validate token and extract user ID
+            jwtTokenProvider.validateAccessToken(jwt);
+            UUID userId = jwtTokenProvider.getUserIdFromToken(jwt);
+
+            // Load user details (authorities are taken from DB, not token)
+            UserDetails userDetails =
+                    userDetailsService.loadUserByUsername(userId.toString());
+
+            // Create authentication object for Spring Security
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            null,
+                            userDetails.getAuthorities()
+                    );
+
+            // Attach request metadata (IP, session info, etc.)
+            authentication.setDetails(
+                    new WebAuthenticationDetailsSource().buildDetails(request)
+            );
+
+            // Store authentication in SecurityContext
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            log.debug("JWT authentication successful for userId={}", userId);
+
+        } catch (JwtTokenExpiredException ex) {
+            // Token is valid but expired (client should refresh)
+            log.debug("JWT expired: {}", ex.getMessage());
+
+        } catch (JwtTokenInvalidException ex) {
+            // Token is malformed or tampered with
+            log.warn("Invalid JWT: {}", ex.getMessage());
+
+        } catch (Exception ex) {
+            // Any unexpected authentication failure
+            log.error("JWT authentication failed", ex);
+        }
+
+        // Continue with remaining filters
         filterChain.doFilter(request, response);
     }
 
-    // Extract JWT token from Authorization header
+    // Extracts JWT from Authorization: Bearer <token>
     private String getJwtFromRequest(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
+        String header = request.getHeader(AUTH_HEADER);
 
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7); // Remove "Bearer " prefix
+        if (StringUtils.hasText(header) && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length());
         }
-
         return null;
     }
 
-    // Skip JWT filter for public and auth-related endpoints to avoid unnecessary token parsing and interfering with auth flows
+    // Skip JWT processing for public/auth endpoints
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getServletPath();
-
-        return path.startsWith("/api/auth/")
-                || path.startsWith("/oauth2/")
-                || path.startsWith("/login/oauth2/");
+        return PUBLIC_ENDPOINTS.stream().anyMatch(path::startsWith);
     }
 }

--- a/src/main/java/com/mockify/backend/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/mockify/backend/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -2,10 +2,10 @@ package com.mockify.backend.security.oauth2;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mockify.backend.common.enums.UserRole;
 import com.mockify.backend.mapper.UserMapper;
 import com.mockify.backend.model.User;
 import com.mockify.backend.repository.UserRepository;
-import com.mockify.backend.dto.response.auth.AuthResponse;
 import com.mockify.backend.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -69,6 +68,8 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
         User user = userRepository.findByEmail(email).orElseGet(() -> {
             User newUser = new User();
             newUser.setEmail(email);
+            newUser.setEmailVerified(true);
+            newUser.setRole(UserRole.USER);
             newUser.setName(name != null ? name : email);
             newUser.setProviderName("google");
             newUser.setProviderId(providerId);
@@ -82,7 +83,7 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
         });
 
         // Issue JWTs
-        String accessToken = jwtTokenProvider.generateAccessToken(user.getId());
+        String accessToken = jwtTokenProvider.generateAccessToken(user.getId(), UserRole.USER);
 
         // TODO: SECURITY - Set token in HttpOnly cookie instead of URL params
         String encodedAccessToken = URLEncoder.encode(accessToken, StandardCharsets.UTF_8);

--- a/src/main/java/com/mockify/backend/service/AdminService.java
+++ b/src/main/java/com/mockify/backend/service/AdminService.java
@@ -1,0 +1,19 @@
+package com.mockify.backend.service;
+
+import com.mockify.backend.dto.response.admin.*;
+
+import java.util.List;
+
+public interface AdminService {
+
+    List<AdminUserResponse> listUsers();
+
+    List<AdminOrganizationResponse> listOrganizations();
+
+    List<AdminProjectResponse> listProjects();
+
+    List<AdminMockSchemaResponse> listSchemas();
+
+    List<AdminMockRecordResponse> listRecords();
+
+}

--- a/src/main/java/com/mockify/backend/service/AuthService.java
+++ b/src/main/java/com/mockify/backend/service/AuthService.java
@@ -1,6 +1,6 @@
 package com.mockify.backend.service;
 
-import com.mockify.backend.dto.response.AuthResult;
+import com.mockify.backend.dto.response.auth.AuthResult;
 import com.mockify.backend.dto.request.auth.LoginRequest;
 import com.mockify.backend.dto.request.auth.RegisterRequest;
 import com.mockify.backend.dto.response.auth.UserResponse;

--- a/src/main/java/com/mockify/backend/service/impl/AdminServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/AdminServiceImpl.java
@@ -1,0 +1,60 @@
+package com.mockify.backend.service.impl;
+
+import com.mockify.backend.dto.response.admin.AdminUserResponse;
+import com.mockify.backend.dto.response.admin.AdminOrganizationResponse;
+import com.mockify.backend.dto.response.admin.AdminProjectResponse;
+import com.mockify.backend.dto.response.admin.AdminMockSchemaResponse;
+import com.mockify.backend.dto.response.admin.AdminMockRecordResponse;
+import com.mockify.backend.mapper.admin.*;
+import com.mockify.backend.repository.*;
+import com.mockify.backend.service.AdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminServiceImpl implements AdminService {
+
+    private final UserRepository userRepository;
+    private final OrganizationRepository organizationRepository;
+    private final ProjectRepository projectRepository;
+    private final MockSchemaRepository mockSchemaRepository;
+    private final MockRecordRepository mockRecordRepository;
+
+    private final AdminUserMapper userMapper;
+    private final AdminOrganizationMapper organizationMapper;
+    private final AdminProjectMapper projectMapper;
+    private final AdminMockSchemaMapper schemaMapper;
+    private final AdminMockRecordMapper recordMapper;
+
+    @Override
+    public List<AdminUserResponse> listUsers() {
+        return userMapper.toResponseList(userRepository.findAll());
+    }
+
+    @Override
+    public List<AdminOrganizationResponse> listOrganizations() {
+        return organizationMapper.toResponseList(organizationRepository.findAll());
+    }
+
+    @Override
+    public List<AdminProjectResponse> listProjects() {
+        return projectMapper.toResponseList(projectRepository.findAll());
+    }
+
+    @Override
+    public List<AdminMockSchemaResponse> listSchemas() {
+        return schemaMapper.toResponseList(mockSchemaRepository.findAll());
+    }
+
+    @Override
+    public List<AdminMockRecordResponse> listRecords() {
+        return recordMapper.toResponseList(mockRecordRepository.findAll());
+    }
+
+    // TODO: Leter we add promote/demote users
+}

--- a/src/main/resources/db/migration/V9__add_email_verification_roles_and_seed_admin.sql
+++ b/src/main/resources/db/migration/V9__add_email_verification_roles_and_seed_admin.sql
@@ -12,11 +12,13 @@ ALTER TABLE users
 ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'USER';
 
 -- Insert default admin user only if it does not already exist
-INSERT INTO users (id, name, email, password, role, provider_name, created_at)
+INSERT INTO users (id, name, username, email, email_verified, password, role, provider_name, created_at)
 SELECT
     gen_random_uuid(),
     'Mockify Admin',
+    'mockify',
     'mockify.noreply@gmail.com',
+     true,
     '$2a$10$REPLACE_WITH_BCRYPT_HASH',          -- Replace with real bcrypt hash (use reset password)
     'ADMIN',
     'local',

--- a/src/main/resources/db/migration/V9__add_email_verification_roles_and_seed_admin.sql
+++ b/src/main/resources/db/migration/V9__add_email_verification_roles_and_seed_admin.sql
@@ -1,0 +1,27 @@
+-- Indicates whether the user's email address has been verified
+-- Defaults to FALSE for existing and newly created users
+ALTER TABLE users
+ADD COLUMN email_verified BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Index to speed up queries filtering verified vs unverified users
+CREATE INDEX idx_users_email_verified ON users (email_verified);
+
+
+-- Add role column and set existing users to USER
+ALTER TABLE users
+ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'USER';
+
+-- Insert default admin user only if it does not already exist
+INSERT INTO users (id, name, email, password, role, provider_name, created_at)
+SELECT
+    gen_random_uuid(),
+    'Mockify Admin',
+    'mockify.noreply@gmail.com',
+    '$2a$10$REPLACE_WITH_BCRYPT_HASH',          -- Replace with real bcrypt hash (use reset password)
+    'ADMIN',
+    'local',
+    NOW()
+WHERE NOT EXISTS (
+    SELECT 1 FROM users WHERE email = 'mockify.noreply@gmail.com'
+);
+


### PR DESCRIPTION
# What’s done in this PR

## 1. Email verification flag

- Added emailVerified field to User
- Marked email as verified after successful email verification
- Fixes a missing step from the earlier auth flow

## 2. Role support (USER / ADMIN)

- Added role field to User
- Default role is USER to prevent accidental admin creation
- Seeded a default ADMIN via migration
- Role is now propagated through JWT and Spring Security

## 3. Database migrations

**Added migration for:**
- email_verified
- role
- default admin seeding
- Existing users are safely migrated as USER

## 4. Admin read-only visibility APIs

**Added admin-only endpoints to view platform data:**

- Users
- Organizations
- Projects
- Mock Schemas
- Mock Records

**All endpoints are:**

- Read-only
- DTO-based (no entities exposed)
- Protected by ROLE_ADMIN

## 5. Admin authority & security rules

- Defined `/api/admin/**` as ADMIN-only
- Proper role → authority mapping (ROLE_ADMIN)
- Uses `@PreAuthorize` for clarity and safety

## 6. JWT filter optimization

- Overrode shouldNotFilter
- Skips JWT processing for public auth endpoints (forgot/reset password, login, etc.)
- Prevents unnecessary auth failures and extra work