### PR TITLE
 Feature: Automatic Mock Record Generation for API Testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,12 @@
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
 
+		<!-- Javafaker-->
+		<dependency>
+			<groupId>com.github.javafaker</groupId>
+			<artifactId>javafaker</artifactId>
+			<version>1.0.2</version>
+		</dependency>
 
     </dependencies>
 

--- a/src/main/java/com/mockify/backend/config/SecurityConfig.java
+++ b/src/main/java/com/mockify/backend/config/SecurityConfig.java
@@ -124,7 +124,7 @@ public class SecurityConfig {
                 .addFilterAfter(rateLimitFilter, ApiKeyAuthenticationFilter.class)
 
                 // 4. API Key-specific rate limiting (per key quotas, stricter limits)
-                .addFilterAfter(apiKeyRateLimitFilter, RateLimitFilter.class)
+                .addFilterAfter(apiKeyRateLimitFilter, RateLimitFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/mockify/backend/controller/MockRecordController.java
+++ b/src/main/java/com/mockify/backend/controller/MockRecordController.java
@@ -1,151 +1,178 @@
 package com.mockify.backend.controller;
 
+import com.mockify.backend.dto.request.record.AutoGenerateRequest;
 import com.mockify.backend.dto.request.record.CreateMockRecordRequest;
 import com.mockify.backend.dto.request.record.UpdateMockRecordRequest;
-import com.mockify.backend.dto.response.page.PageResponse;
 import com.mockify.backend.dto.response.record.MockRecordResponse;
-import com.mockify.backend.security.SecurityUtils;
 import com.mockify.backend.service.EndpointService;
 import com.mockify.backend.service.MockRecordService;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
 
-/**
- * Mock Record management controller.
- * <h3>AUTHORIZATION</h3>
-   * <p>All methods are open to both JWT sessions and API key callers. Authorization
-   * is enforced declaratively via {@code @PreAuthorize("hasPermission(...)")}
-   * annotations on each {@link MockRecordService} method, evaluated by
-   * {@link com.mockify.backend.security.MockifyPermissionEvaluator}.</p>
-   *
-   * <ul>
-   *   <li><b>JWT callers</b>: full access to all resources within their owned organization.</li>
-   *   <li><b>API key callers</b>: access gated by three sequential guards —
-   *       org scope → project scope → permission level
-   *       (hierarchy: ADMIN ⊇ DELETE ⊇ WRITE ⊇ READ).</li>
-   * </ul>
- */
-@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
-@Tag(name = "Mock Record")
+@Slf4j
 public class MockRecordController {
 
     private final MockRecordService mockRecordService;
     private final EndpointService endpointService;
 
-    // Create a new mock record
+    private UUID extractUserId(UserDetails userDetails) {
+        return UUID.fromString(userDetails.getUsername());
+    }
+
+    private UUID resolveSchemaId(String org, String project, String schema) {
+        return endpointService.resolveSchema(org, project, schema);
+    }
+
+    // -------------------------------------------------------------------------
+    // CREATE
+    // -------------------------------------------------------------------------
+
     @PostMapping("/{org}/{project}/{schema}/records")
     public ResponseEntity<MockRecordResponse> createRecord(
             @PathVariable String org,
             @PathVariable String project,
             @PathVariable String schema,
             @Valid @RequestBody CreateMockRecordRequest request,
-            Authentication auth) {
+            @AuthenticationPrincipal UserDetails userDetails) {
 
-        UUID userId = SecurityUtils.resolveUserId(auth);
-        UUID schemaId = endpointService.resolveSchema(org, project, schema);
-        log.info("User {} creating new mock record under schema {}", userId, schemaId);
+        UUID userId = extractUserId(userDetails);
+        UUID schemaId = resolveSchemaId(org, project, schema);
 
-        MockRecordResponse created = mockRecordService.createRecord(userId, schemaId, request);
+        MockRecordResponse created =
+                mockRecordService.createRecord(userId, schemaId, request);
+
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
-    // Create multiple records in bulk
+    // -------------------------------------------------------------------------
+    // BULK CREATE
+    // -------------------------------------------------------------------------
+
     @PostMapping("/{org}/{project}/{schema}/records/bulk")
     public ResponseEntity<List<MockRecordResponse>> createRecordsBulk(
             @PathVariable String org,
             @PathVariable String project,
             @PathVariable String schema,
             @Valid @RequestBody List<CreateMockRecordRequest> requests,
-            Authentication auth) {
+            @AuthenticationPrincipal UserDetails userDetails) {
 
-        UUID userId = SecurityUtils.resolveUserId(auth);
-        UUID schemaId = endpointService.resolveSchema(org, project, schema);
-        log.info("User {} bulk creating {} records under schema {}", userId, requests.size(), schemaId);
+        UUID userId = extractUserId(userDetails);
+        UUID schemaId = resolveSchemaId(org, project, schema);
 
-        List<MockRecordResponse> created = mockRecordService.createRecordsBulk(userId, schemaId, requests);
+        List<MockRecordResponse> created =
+                mockRecordService.createRecordsBulk(userId, schemaId, requests);
+
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
-    // Get a record by ID
-    @GetMapping("/{org}/{project}/{schema}/records/{recordId}")
-    public ResponseEntity<MockRecordResponse> getRecordById(
+    // -------------------------------------------------------------------------
+    // AUTO GENERATE
+    // -------------------------------------------------------------------------
+
+    @PostMapping("/{org}/{project}/{schema}/records/auto-bulk")
+    public ResponseEntity<List<MockRecordResponse>> autoGenerateRecordsBulk(
             @PathVariable String org,
             @PathVariable String project,
             @PathVariable String schema,
-            @PathVariable UUID recordId,
-            Authentication auth) {
+            @Valid @RequestBody AutoGenerateRequest request,
+            @AuthenticationPrincipal UserDetails userDetails) {
 
-        UUID userId = SecurityUtils.resolveUserId(auth);
-        log.debug("User {} fetching record with ID {}", userId, recordId);
+        UUID userId = extractUserId(userDetails);
+        UUID schemaId = resolveSchemaId(org, project, schema);
 
-        MockRecordResponse record = mockRecordService.getRecordById(userId, recordId);
-        return ResponseEntity.ok(record);
+        List<MockRecordResponse> records =
+                mockRecordService.autoGenerateRecordsBulk(
+                        userId,
+                        schemaId,
+                        request.getCount()
+                );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(records);
     }
 
-    // Get all records under a specific schema
+    // -------------------------------------------------------------------------
+    // READ (PAGINATED)
+    // -------------------------------------------------------------------------
+
     @GetMapping("/{org}/{project}/{schema}/records")
-    public ResponseEntity<PageResponse<MockRecordResponse>> getRecords(
+    public ResponseEntity<Page<MockRecordResponse>> getRecords(
             @PathVariable String org,
             @PathVariable String project,
             @PathVariable String schema,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
-            Authentication auth) {
+            Pageable pageable,
+            @AuthenticationPrincipal UserDetails userDetails) {
 
-        UUID userId = SecurityUtils.resolveUserId(auth);
-        UUID schemaId = endpointService.resolveSchema(org, project, schema);
+        UUID userId = extractUserId(userDetails);
+        UUID schemaId = resolveSchemaId(org, project, schema);
 
         Page<MockRecordResponse> page =
                 mockRecordService.getRecordsBySchemaId(userId, schemaId, pageable);
 
-        return ResponseEntity.ok(PageResponse.from(page));
+        return ResponseEntity.ok(page);
     }
 
-    // Update an existing mock record
+    // -------------------------------------------------------------------------
+    // GET BY ID
+    // -------------------------------------------------------------------------
+
+    @GetMapping("/{org}/{project}/{schema}/records/{recordId}")
+    public ResponseEntity<MockRecordResponse> getRecordById(
+            @PathVariable UUID recordId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        UUID userId = extractUserId(userDetails);
+
+        MockRecordResponse record =
+                mockRecordService.getRecordById(userId, recordId);
+
+        return ResponseEntity.ok(record);
+    }
+
+    // -------------------------------------------------------------------------
+    // UPDATE
+    // -------------------------------------------------------------------------
+
     @PutMapping("/{org}/{project}/{schema}/records/{recordId}")
     public ResponseEntity<MockRecordResponse> updateRecord(
-            @PathVariable String org,
-            @PathVariable String project,
-            @PathVariable String schema,
             @PathVariable UUID recordId,
             @Valid @RequestBody UpdateMockRecordRequest request,
-            Authentication auth) {
+            @AuthenticationPrincipal UserDetails userDetails) {
 
-        UUID userId = SecurityUtils.resolveUserId(auth);
-        log.info("User {} updating record ID {}", userId, recordId);
+        UUID userId = extractUserId(userDetails);
 
-        MockRecordResponse updated = mockRecordService.updateRecord(userId, recordId, request);
+        MockRecordResponse updated =
+                mockRecordService.updateRecord(userId, recordId, request);
+
         return ResponseEntity.ok(updated);
     }
 
-    // Delete a record by ID
+    // -------------------------------------------------------------------------
+    // DELETE
+    // -------------------------------------------------------------------------
+
     @DeleteMapping("/{org}/{project}/{schema}/records/{recordId}")
     public ResponseEntity<Void> deleteRecord(
-            @PathVariable String org,
-            @PathVariable String project,
-            @PathVariable String schema,
             @PathVariable UUID recordId,
-            Authentication auth) {
+            @AuthenticationPrincipal UserDetails userDetails) {
 
-        UUID userId = SecurityUtils.resolveUserId(auth);
-        log.warn("User {} deleting record ID {}", userId, recordId);
+        UUID userId = extractUserId(userDetails);
 
         mockRecordService.deleteRecord(userId, recordId);
+
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mockify/backend/controller/MockRecordController.java
+++ b/src/main/java/com/mockify/backend/controller/MockRecordController.java
@@ -3,176 +3,169 @@ package com.mockify.backend.controller;
 import com.mockify.backend.dto.request.record.AutoGenerateRequest;
 import com.mockify.backend.dto.request.record.CreateMockRecordRequest;
 import com.mockify.backend.dto.request.record.UpdateMockRecordRequest;
+import com.mockify.backend.dto.response.page.PageResponse;
 import com.mockify.backend.dto.response.record.MockRecordResponse;
+import com.mockify.backend.security.SecurityUtils;
 import com.mockify.backend.service.EndpointService;
 import com.mockify.backend.service.MockRecordService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Mock Record management controller.
+ * <h3>AUTHORIZATION</h3>
+ * <p>All methods are open to both JWT sessions and API key callers. Authorization
+ * is enforced declaratively via {@code @PreAuthorize("hasPermission(...)")}
+ * annotations on each {@link MockRecordService} method, evaluated by
+ * {@link com.mockify.backend.security.MockifyPermissionEvaluator}.</p>
+ *
+ * <ul>
+ *   <li><b>JWT callers</b>: full access to all resources within their owned organization.</li>
+ *   <li><b>API key callers</b>: access gated by three sequential guards —
+ *       org scope → project scope → permission level
+ *       (hierarchy: ADMIN ⊇ DELETE ⊇ WRITE ⊇ READ).</li>
+ * </ul>
+ */
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
-@Slf4j
+@Tag(name = "Mock Record")
 public class MockRecordController {
 
     private final MockRecordService mockRecordService;
     private final EndpointService endpointService;
 
-    private UUID extractUserId(UserDetails userDetails) {
-        return UUID.fromString(userDetails.getUsername());
-    }
-
-    private UUID resolveSchemaId(String org, String project, String schema) {
-        return endpointService.resolveSchema(org, project, schema);
-    }
-
-    // -------------------------------------------------------------------------
-    // CREATE
-    // -------------------------------------------------------------------------
-
+    // Create a new mock record
     @PostMapping("/{org}/{project}/{schema}/records")
     public ResponseEntity<MockRecordResponse> createRecord(
             @PathVariable String org,
             @PathVariable String project,
             @PathVariable String schema,
             @Valid @RequestBody CreateMockRecordRequest request,
-            @AuthenticationPrincipal UserDetails userDetails) {
+            Authentication auth) {
 
-        UUID userId = extractUserId(userDetails);
-        UUID schemaId = resolveSchemaId(org, project, schema);
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        UUID schemaId = endpointService.resolveSchema(org, project, schema);
+        log.info("User {} creating new mock record under schema {}", userId, schemaId);
 
-        MockRecordResponse created =
-                mockRecordService.createRecord(userId, schemaId, request);
-
+        MockRecordResponse created = mockRecordService.createRecord(userId, schemaId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
-    // -------------------------------------------------------------------------
-    // BULK CREATE
-    // -------------------------------------------------------------------------
-
+    // Create multiple records in bulk
     @PostMapping("/{org}/{project}/{schema}/records/bulk")
     public ResponseEntity<List<MockRecordResponse>> createRecordsBulk(
             @PathVariable String org,
             @PathVariable String project,
             @PathVariable String schema,
             @Valid @RequestBody List<CreateMockRecordRequest> requests,
-            @AuthenticationPrincipal UserDetails userDetails) {
+            Authentication auth) {
 
-        UUID userId = extractUserId(userDetails);
-        UUID schemaId = resolveSchemaId(org, project, schema);
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        UUID schemaId = endpointService.resolveSchema(org, project, schema);
+        log.info("User {} bulk creating {} records under schema {}", userId, requests.size(), schemaId);
 
-        List<MockRecordResponse> created =
-                mockRecordService.createRecordsBulk(userId, schemaId, requests);
-
+        List<MockRecordResponse> created = mockRecordService.createRecordsBulk(userId, schemaId, requests);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
-    // -------------------------------------------------------------------------
-    // AUTO GENERATE
-    // -------------------------------------------------------------------------
-
+    // Auto-generate multiple records
     @PostMapping("/{org}/{project}/{schema}/records/auto-bulk")
     public ResponseEntity<List<MockRecordResponse>> autoGenerateRecordsBulk(
             @PathVariable String org,
             @PathVariable String project,
             @PathVariable String schema,
             @Valid @RequestBody AutoGenerateRequest request,
-            @AuthenticationPrincipal UserDetails userDetails) {
+            Authentication auth) {
 
-        UUID userId = extractUserId(userDetails);
-        UUID schemaId = resolveSchemaId(org, project, schema);
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        UUID schemaId = endpointService.resolveSchema(org, project, schema);
+        log.info("User {} auto-generating {} records under schema {}", userId, request.getCount(), schemaId);
 
         List<MockRecordResponse> records =
-                mockRecordService.autoGenerateRecordsBulk(
-                        userId,
-                        schemaId,
-                        request.getCount()
-                );
+                mockRecordService.autoGenerateRecordsBulk(userId, schemaId, request.getCount());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(records);
     }
 
-    // -------------------------------------------------------------------------
-    // READ (PAGINATED)
-    // -------------------------------------------------------------------------
-
-    @GetMapping("/{org}/{project}/{schema}/records")
-    public ResponseEntity<Page<MockRecordResponse>> getRecords(
+    // Get a record by ID
+    @GetMapping("/{org}/{project}/{schema}/records/{recordId}")
+    public ResponseEntity<MockRecordResponse> getRecordById(
             @PathVariable String org,
             @PathVariable String project,
             @PathVariable String schema,
-            Pageable pageable,
-            @AuthenticationPrincipal UserDetails userDetails) {
+            @PathVariable UUID recordId,
+            Authentication auth) {
 
-        UUID userId = extractUserId(userDetails);
-        UUID schemaId = resolveSchemaId(org, project, schema);
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        log.debug("User {} fetching record with ID {}", userId, recordId);
+
+        MockRecordResponse record = mockRecordService.getRecordById(userId, recordId);
+        return ResponseEntity.ok(record);
+    }
+
+    // Get all records under a specific schema
+    @GetMapping("/{org}/{project}/{schema}/records")
+    public ResponseEntity<PageResponse<MockRecordResponse>> getRecords(
+            @PathVariable String org,
+            @PathVariable String project,
+            @PathVariable String schema,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            Authentication auth) {
+
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        UUID schemaId = endpointService.resolveSchema(org, project, schema);
 
         Page<MockRecordResponse> page =
                 mockRecordService.getRecordsBySchemaId(userId, schemaId, pageable);
 
-        return ResponseEntity.ok(page);
+        return ResponseEntity.ok(PageResponse.from(page));
     }
 
-    // -------------------------------------------------------------------------
-    // GET BY ID
-    // -------------------------------------------------------------------------
-
-    @GetMapping("/{org}/{project}/{schema}/records/{recordId}")
-    public ResponseEntity<MockRecordResponse> getRecordById(
-            @PathVariable UUID recordId,
-            @AuthenticationPrincipal UserDetails userDetails) {
-
-        UUID userId = extractUserId(userDetails);
-
-        MockRecordResponse record =
-                mockRecordService.getRecordById(userId, recordId);
-
-        return ResponseEntity.ok(record);
-    }
-
-    // -------------------------------------------------------------------------
-    // UPDATE
-    // -------------------------------------------------------------------------
-
+    // Update an existing mock record
     @PutMapping("/{org}/{project}/{schema}/records/{recordId}")
     public ResponseEntity<MockRecordResponse> updateRecord(
+            @PathVariable String org,
+            @PathVariable String project,
+            @PathVariable String schema,
             @PathVariable UUID recordId,
             @Valid @RequestBody UpdateMockRecordRequest request,
-            @AuthenticationPrincipal UserDetails userDetails) {
+            Authentication auth) {
 
-        UUID userId = extractUserId(userDetails);
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        log.info("User {} updating record ID {}", userId, recordId);
 
-        MockRecordResponse updated =
-                mockRecordService.updateRecord(userId, recordId, request);
-
+        MockRecordResponse updated = mockRecordService.updateRecord(userId, recordId, request);
         return ResponseEntity.ok(updated);
     }
 
-    // -------------------------------------------------------------------------
-    // DELETE
-    // -------------------------------------------------------------------------
-
+    // Delete a record by ID
     @DeleteMapping("/{org}/{project}/{schema}/records/{recordId}")
     public ResponseEntity<Void> deleteRecord(
+            @PathVariable String org,
+            @PathVariable String project,
+            @PathVariable String schema,
             @PathVariable UUID recordId,
-            @AuthenticationPrincipal UserDetails userDetails) {
+            Authentication auth) {
 
-        UUID userId = extractUserId(userDetails);
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        log.warn("User {} deleting record ID {}", userId, recordId);
 
         mockRecordService.deleteRecord(userId, recordId);
-
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mockify/backend/dto/request/record/AutoGenerateRequest.java
+++ b/src/main/java/com/mockify/backend/dto/request/record/AutoGenerateRequest.java
@@ -1,0 +1,13 @@
+package com.mockify.backend.dto.request.record;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Data;
+
+@Data
+public class AutoGenerateRequest {
+    @Min(1)
+    @Max(1000)
+    private int count;
+
+}

--- a/src/main/java/com/mockify/backend/service/MockAutoGenerateService.java
+++ b/src/main/java/com/mockify/backend/service/MockAutoGenerateService.java
@@ -1,0 +1,7 @@
+package com.mockify.backend.service;
+
+import java.util.Map;
+
+public interface MockAutoGenerateService {
+    Map<String, Object> generateRecord(Map<String, Object> schemaJson);
+}

--- a/src/main/java/com/mockify/backend/service/MockRecordService.java
+++ b/src/main/java/com/mockify/backend/service/MockRecordService.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 public interface MockRecordService {
@@ -15,6 +14,8 @@ public interface MockRecordService {
     MockRecordResponse createRecord(UUID userId, UUID schemaId, CreateMockRecordRequest request);
 
     List<MockRecordResponse> createRecordsBulk(UUID userId, UUID schemaId, List<CreateMockRecordRequest> requests);
+
+    List<MockRecordResponse> autoGenerateRecordsBulk(UUID userId, UUID schemaId, int count);
 
     MockRecordResponse getRecordById(UUID userId, UUID recordId);
 

--- a/src/main/java/com/mockify/backend/service/impl/MockAutoGenerateServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockAutoGenerateServiceImpl.java
@@ -1,0 +1,76 @@
+package com.mockify.backend.service.impl;
+
+import com.github.javafaker.Faker;
+import com.mockify.backend.service.MockAutoGenerateService;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.function.Supplier;
+
+@Service
+public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
+
+    private final Faker faker = new Faker();
+
+    // Exact field generators (base definitions)
+    private final Map<String, Supplier<Object>> fieldGenerators = Map.of(
+            "email", () -> faker.internet().emailAddress(),
+            "username", () -> faker.name().username(),
+            "id", () -> faker.number().numberBetween(1, 100000),
+            "name", () -> faker.name().fullName()
+    );
+
+    // Type-based generators
+    private final Map<String, Supplier<Object>> typeGenerators = Map.of(
+            "string", () -> faker.lorem().word(),
+            "number", () -> faker.number().numberBetween(1, 1000),
+            "boolean", () -> faker.bool().bool(),
+            "array", () -> List.of(faker.lorem().word(), faker.number().randomDigit()),
+            "object", () -> Map.of("value", faker.lorem().word())
+    );
+
+    @Override
+    public Map<String, Object> generateRecord(Map<String, Object> schemaJson) {
+        Map<String, Object> record = new LinkedHashMap<>();
+
+        for (Map.Entry<String, Object> entry : schemaJson.entrySet()) {
+
+            String field = entry.getKey();
+            String type = String.valueOf(entry.getValue()).toLowerCase();
+
+            Supplier<Object> generator = resolveFieldGenerator(field)
+                    .orElseGet(() -> resolveTypeGenerator(type));
+
+            record.put(field, generator.get());
+        }
+
+        return record;
+    }
+
+    /**
+     * Try to resolve generator based on field name (fuzzy matching)
+     */
+    private Optional<Supplier<Object>> resolveFieldGenerator(String field) {
+        String f = field.toLowerCase();
+
+        if (f.contains("email")) return Optional.of(fieldGenerators.get("email"));
+        if (f.contains("username")) return Optional.of(fieldGenerators.get("username"));
+        if (f.equals("id") || f.endsWith("id")) return Optional.of(fieldGenerators.get("id"));
+        if (f.contains("name")) return Optional.of(fieldGenerators.get("name"));
+
+        return Optional.empty();
+    }
+
+    /**
+     * Resolve generator based on type or throw clear error
+     */
+    private Supplier<Object> resolveTypeGenerator(String type) {
+        Supplier<Object> generator = typeGenerators.get(type);
+
+        if (generator == null) {
+            throw new IllegalArgumentException("Unsupported field type: " + type);
+        }
+
+        return generator;
+    }
+}

--- a/src/main/java/com/mockify/backend/service/impl/MockAutoGenerateServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockAutoGenerateServiceImpl.java
@@ -11,6 +11,7 @@ import java.util.function.Supplier;
 public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
 
     private final Faker faker = new Faker();
+    private final Random random = new Random();
 
     // Exact field generators (base definitions)
     private final Map<String, Supplier<Object>> fieldGenerators = Map.of(
@@ -36,10 +37,12 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
         for (Map.Entry<String, Object> entry : schemaJson.entrySet()) {
 
             String field = entry.getKey();
-            String type = String.valueOf(entry.getValue()).toLowerCase();
+            Object schemaDef = entry.getValue();
+
+            ParsedSchema parsed = parseSchema(field, schemaDef);
 
             Supplier<Object> generator = resolveFieldGenerator(field)
-                    .orElseGet(() -> resolveTypeGenerator(type));
+                    .orElseGet(() -> resolveTypeGenerator(parsed.type(), parsed.enumValues()));
 
             record.put(field, generator.get());
         }
@@ -48,15 +51,49 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
     }
 
     /**
+     * Parse schema definition safely
+     */
+    private ParsedSchema parseSchema(String field, Object schemaDef) {
+
+        if (schemaDef instanceof String s) {
+            return new ParsedSchema(s.toLowerCase(), null);
+        }
+
+        if (schemaDef instanceof Map<?, ?> defMap) {
+
+            Object typeObj = defMap.get("type");
+            if (!(typeObj instanceof String typeStr)) {
+                throw new IllegalArgumentException(
+                        "Missing or invalid 'type' for field: " + field
+                );
+            }
+
+            List<?> enumValues = null;
+            Object valuesObj = defMap.get("values");
+            if (valuesObj instanceof List<?>) {
+                enumValues = (List<?>) valuesObj;
+            }
+
+            return new ParsedSchema(typeStr.toLowerCase(), enumValues);
+        }
+
+        throw new IllegalArgumentException(
+                "Invalid schema format for field: " + field
+        );
+    }
+
+    /**
      * Try to resolve generator based on field name (fuzzy matching)
      */
     private Optional<Supplier<Object>> resolveFieldGenerator(String field) {
         String f = field.toLowerCase();
 
-        if (f.contains("email")) return Optional.of(fieldGenerators.get("email"));
-        if (f.contains("username")) return Optional.of(fieldGenerators.get("username"));
-        if (f.equals("id") || f.endsWith("id")) return Optional.of(fieldGenerators.get("id"));
-        if (f.contains("name")) return Optional.of(fieldGenerators.get("name"));
+
+        if (f.contains("email")) return Optional.ofNullable(fieldGenerators.get("email"));
+        if (f.contains("username")) return Optional.ofNullable(fieldGenerators.get("username"));
+        if (f.equals("id") || f.endsWith("id")) return Optional.ofNullable(fieldGenerators.get("id"));
+        if (f.contains("name")) return Optional.ofNullable(fieldGenerators.get("name"));
+
 
         return Optional.empty();
     }
@@ -64,7 +101,18 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
     /**
      * Resolve generator based on type or throw clear error
      */
-    private Supplier<Object> resolveTypeGenerator(String type) {
+    /**
+     * Type-based generator with ENUM support
+     */
+    private Supplier<Object> resolveTypeGenerator(String type, List<?> enumValues) {
+
+        if ("enum".equals(type)) {
+            if (enumValues == null || enumValues.isEmpty()) {
+                throw new IllegalArgumentException("ENUM type requires non-empty values list");
+            }
+            return () -> enumValues.get(random.nextInt(enumValues.size()));
+        }
+
         Supplier<Object> generator = typeGenerators.get(type);
 
         if (generator == null) {
@@ -73,4 +121,9 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
 
         return generator;
     }
+
+    /**
+     * Internal record for parsed schema
+     */
+    private record ParsedSchema(String type, List<?> enumValues) {}
 }

--- a/src/main/java/com/mockify/backend/service/impl/MockAutoGenerateServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockAutoGenerateServiceImpl.java
@@ -133,15 +133,47 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
         if (f.contains("username"))
             return Optional.ofNullable(fieldGenerators.get("username"));
 
+        if (f.contains("uuid"))
+            return Optional.ofNullable(fieldGenerators.get("uuid"));
+
+        if (f.contains("url"))
+            return Optional.ofNullable(fieldGenerators.get("url"));
+
+        if (f.contains("phone"))
+            return Optional.ofNullable(fieldGenerators.get("phone"));
+
         if (f.equals("id") || f.endsWith("id"))
             return Optional.ofNullable(fieldGenerators.get("id"));
 
         if (f.contains("name"))
             return Optional.ofNullable(fieldGenerators.get("name"));
 
+        if (f.contains("city"))
+            return Optional.ofNullable(fieldGenerators.get("city"));
+
+        if (f.contains("state"))
+            return Optional.ofNullable(fieldGenerators.get("state"));
+
+        if (f.contains("country"))
+            return Optional.ofNullable(fieldGenerators.get("country"));
+
+        if (f.contains("zipcode"))
+            return Optional.ofNullable(fieldGenerators.get("zipCode"));
+
+        if (f.contains("company"))
+            return Optional.ofNullable(fieldGenerators.get("company"));
+
+        if (f.contains("title"))
+            return Optional.ofNullable(fieldGenerators.get("title"));
+
+        if (f.contains("createdat"))
+            return Optional.ofNullable(fieldGenerators.get("createdAt"));
+
+        if (f.contains("updatedat"))
+            return Optional.ofNullable(fieldGenerators.get("updatedAt"));
+
         return Optional.empty();
     }
-
     /**
      * Resolve generator based on type or throw clear error
      */

--- a/src/main/java/com/mockify/backend/service/impl/MockAutoGenerateServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockAutoGenerateServiceImpl.java
@@ -4,34 +4,64 @@ import com.github.javafaker.Faker;
 import com.mockify.backend.service.MockAutoGenerateService;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
 @Service
 public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
 
-    private final Faker faker = new Faker();
-    private final Random random = new Random();
+    private static final ThreadLocal<Faker> FAKER =
+            ThreadLocal.withInitial(Faker::new);
 
-    // Exact field generators (base definitions)
-    private final Map<String, Supplier<Object>> fieldGenerators = Map.of(
-            "email", () -> faker.internet().emailAddress(),
-            "username", () -> faker.name().username(),
-            "id", () -> faker.number().numberBetween(1, 100000),
-            "name", () -> faker.name().fullName()
+    private Faker faker() {
+        return FAKER.get();
+    }
+
+    // Exact field generators
+    private final Map<String, Supplier<Object>> fieldGenerators = Map.ofEntries(
+            Map.entry("id", () -> faker().number().numberBetween(1, 100000)),
+            Map.entry("name", () -> faker().name().fullName()),
+            Map.entry("firstName", () -> faker().name().firstName()),
+            Map.entry("lastName", () -> faker().name().lastName()),
+            Map.entry("username", () -> faker().name().username()),
+            Map.entry("email", () -> faker().internet().emailAddress()),
+            Map.entry("phone", () -> faker().phoneNumber().cellPhone()),
+            Map.entry("city", () -> faker().address().city()),
+            Map.entry("state", () -> faker().address().state()),
+            Map.entry("country", () -> faker().address().country()),
+            Map.entry("zipCode", () -> faker().address().zipCode()),
+            Map.entry("company", () -> faker().company().name()),
+            Map.entry("title", () -> faker().job().title()),
+            Map.entry("createdAt", () -> Instant.now().toString()),
+            Map.entry("updatedAt", () -> Instant.now().toString()),
+            Map.entry("uuid", () -> UUID.randomUUID().toString()),
+            Map.entry("url", () -> faker().internet().url())
     );
 
     // Type-based generators
-    private final Map<String, Supplier<Object>> typeGenerators = Map.of(
-            "string", () -> faker.lorem().word(),
-            "number", () -> faker.number().numberBetween(1, 1000),
-            "boolean", () -> faker.bool().bool(),
-            "array", () -> List.of(faker.lorem().word(), faker.number().randomDigit()),
-            "object", () -> Map.of("value", faker.lorem().word())
+    private final Map<String, Supplier<Object>> typeGenerators = Map.ofEntries(
+            Map.entry("string", () -> faker().lorem().word()),
+            Map.entry("number", () -> faker().number().numberBetween(1, 1000)),
+            Map.entry("boolean", () -> faker().bool().bool()),
+            Map.entry("date", () -> LocalDate.now().toString()),
+            Map.entry("date-time", () -> Instant.now().toString()),
+            Map.entry("uuid", () -> UUID.randomUUID().toString()),
+            Map.entry("url", () -> faker().internet().url()),
+            Map.entry("array", () -> List.of(
+                    faker().lorem().word(),
+                    faker().number().randomDigit()
+            )),
+            Map.entry("object", () -> Map.of(
+                    "value", faker().lorem().word()
+            ))
     );
 
     @Override
     public Map<String, Object> generateRecord(Map<String, Object> schemaJson) {
+
         Map<String, Object> record = new LinkedHashMap<>();
 
         for (Map.Entry<String, Object> entry : schemaJson.entrySet()) {
@@ -42,7 +72,12 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
             ParsedSchema parsed = parseSchema(field, schemaDef);
 
             Supplier<Object> generator = resolveFieldGenerator(field)
-                    .orElseGet(() -> resolveTypeGenerator(parsed.type(), parsed.enumValues()));
+                    .orElseGet(() ->
+                            resolveTypeGenerator(
+                                    parsed.type(),
+                                    parsed.enumValues()
+                            )
+                    );
 
             record.put(field, generator.get());
         }
@@ -62,6 +97,7 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
         if (schemaDef instanceof Map<?, ?> defMap) {
 
             Object typeObj = defMap.get("type");
+
             if (!(typeObj instanceof String typeStr)) {
                 throw new IllegalArgumentException(
                         "Missing or invalid 'type' for field: " + field
@@ -69,7 +105,9 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
             }
 
             List<?> enumValues = null;
+
             Object valuesObj = defMap.get("values");
+
             if (valuesObj instanceof List<?>) {
                 enumValues = (List<?>) valuesObj;
             }
@@ -86,14 +124,20 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
      * Try to resolve generator based on field name (fuzzy matching)
      */
     private Optional<Supplier<Object>> resolveFieldGenerator(String field) {
+
         String f = field.toLowerCase();
 
+        if (f.contains("email"))
+            return Optional.ofNullable(fieldGenerators.get("email"));
 
-        if (f.contains("email")) return Optional.ofNullable(fieldGenerators.get("email"));
-        if (f.contains("username")) return Optional.ofNullable(fieldGenerators.get("username"));
-        if (f.equals("id") || f.endsWith("id")) return Optional.ofNullable(fieldGenerators.get("id"));
-        if (f.contains("name")) return Optional.ofNullable(fieldGenerators.get("name"));
+        if (f.contains("username"))
+            return Optional.ofNullable(fieldGenerators.get("username"));
 
+        if (f.equals("id") || f.endsWith("id"))
+            return Optional.ofNullable(fieldGenerators.get("id"));
+
+        if (f.contains("name"))
+            return Optional.ofNullable(fieldGenerators.get("name"));
 
         return Optional.empty();
     }
@@ -107,16 +151,24 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
     private Supplier<Object> resolveTypeGenerator(String type, List<?> enumValues) {
 
         if ("enum".equals(type)) {
+
             if (enumValues == null || enumValues.isEmpty()) {
-                throw new IllegalArgumentException("ENUM type requires non-empty values list");
+                throw new IllegalArgumentException(
+                        "ENUM type requires non-empty values list"
+                );
             }
-            return () -> enumValues.get(random.nextInt(enumValues.size()));
+
+            return () -> enumValues.get(
+                    ThreadLocalRandom.current().nextInt(enumValues.size())
+            );
         }
 
         Supplier<Object> generator = typeGenerators.get(type);
 
         if (generator == null) {
-            throw new IllegalArgumentException("Unsupported field type: " + type);
+            throw new IllegalArgumentException(
+                    "Unsupported field type: " + type
+            );
         }
 
         return generator;

--- a/src/main/java/com/mockify/backend/service/impl/MockAutoGenerateServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockAutoGenerateServiceImpl.java
@@ -46,21 +46,37 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
             Map.entry("string", () -> faker().lorem().word()),
             Map.entry("number", () -> faker().number().numberBetween(1, 1000)),
             Map.entry("boolean", () -> faker().bool().bool()),
+
+            Map.entry("email", () -> faker().internet().emailAddress()),
+
             Map.entry("date", () -> LocalDate.now().toString()),
-            Map.entry("date-time", () -> Instant.now().toString()),
+            Map.entry("datetime", () -> Instant.now().toString()),
+
             Map.entry("uuid", () -> UUID.randomUUID().toString()),
             Map.entry("url", () -> faker().internet().url()),
+
+            Map.entry("null", () -> null),
+
             Map.entry("array", () -> List.of(
                     faker().lorem().word(),
                     faker().number().randomDigit()
             )),
+
             Map.entry("object", () -> Map.of(
                     "value", faker().lorem().word()
+            )),
+
+            Map.entry("json", () -> Map.of(
+                    "key", faker().lorem().word()
             ))
     );
 
     @Override
     public Map<String, Object> generateRecord(Map<String, Object> schemaJson) {
+
+        if (schemaJson == null) {
+            throw new IllegalArgumentException("Schema cannot be null");
+        }
 
         Map<String, Object> record = new LinkedHashMap<>();
 
@@ -71,13 +87,8 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
 
             ParsedSchema parsed = parseSchema(field, schemaDef);
 
-            Supplier<Object> generator = resolveFieldGenerator(field)
-                    .orElseGet(() ->
-                            resolveTypeGenerator(
-                                    parsed.type(),
-                                    parsed.enumValues()
-                            )
-                    );
+            Supplier<Object> generator =
+                    resolveGenerator(field, parsed);
 
             record.put(field, generator.get());
         }
@@ -86,12 +97,41 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
     }
 
     /**
+     * Explicit schema type always wins.
+     * Field-name generators are only used for generic string fields.
+     */
+    private Supplier<Object> resolveGenerator(
+            String field,
+            ParsedSchema parsed
+    ) {
+
+        Supplier<Object> typeGenerator =
+                resolveTypeGenerator(
+                        parsed.type(),
+                        parsed.enumValues()
+                );
+
+        if (!"string".equals(parsed.type())) {
+            return typeGenerator;
+        }
+
+        return resolveFieldGenerator(field)
+                .orElse(typeGenerator);
+    }
+
+    /**
      * Parse schema definition safely
      */
-    private ParsedSchema parseSchema(String field, Object schemaDef) {
+    private ParsedSchema parseSchema(
+            String field,
+            Object schemaDef
+    ) {
 
         if (schemaDef instanceof String s) {
-            return new ParsedSchema(s.toLowerCase(), null);
+            return new ParsedSchema(
+                    s.toLowerCase(),
+                    null
+            );
         }
 
         if (schemaDef instanceof Map<?, ?> defMap) {
@@ -100,7 +140,8 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
 
             if (!(typeObj instanceof String typeStr)) {
                 throw new IllegalArgumentException(
-                        "Missing or invalid 'type' for field: " + field
+                        "Missing or invalid 'type' for field: "
+                                + field
                 );
             }
 
@@ -112,75 +153,88 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
                 enumValues = (List<?>) valuesObj;
             }
 
-            return new ParsedSchema(typeStr.toLowerCase(), enumValues);
+            return new ParsedSchema(
+                    typeStr.toLowerCase(),
+                    enumValues
+            );
         }
 
         throw new IllegalArgumentException(
-                "Invalid schema format for field: " + field
+                "Invalid schema format for field: "
+                        + field
         );
     }
 
     /**
-     * Try to resolve generator based on field name (fuzzy matching)
+     * Safer field-name matching.
+     * Only applied for STRING schema types.
      */
-    private Optional<Supplier<Object>> resolveFieldGenerator(String field) {
+    private Optional<Supplier<Object>> resolveFieldGenerator(
+            String field
+    ) {
 
         String f = field.toLowerCase();
 
-        if (f.contains("email"))
-            return Optional.ofNullable(fieldGenerators.get("email"));
+        switch (f) {
+            case "id":
+                return Optional.ofNullable(fieldGenerators.get("id"));
 
-        if (f.contains("username"))
-            return Optional.ofNullable(fieldGenerators.get("username"));
+            case "name":
+            case "firstname":
+            case "lastname":
+                return Optional.ofNullable(fieldGenerators.get("name"));
 
-        if (f.contains("uuid"))
-            return Optional.ofNullable(fieldGenerators.get("uuid"));
+            case "username":
+                return Optional.ofNullable(fieldGenerators.get("username"));
 
-        if (f.contains("url"))
-            return Optional.ofNullable(fieldGenerators.get("url"));
+            case "email":
+                return Optional.ofNullable(fieldGenerators.get("email"));
 
-        if (f.contains("phone"))
-            return Optional.ofNullable(fieldGenerators.get("phone"));
+            case "phone":
+                return Optional.ofNullable(fieldGenerators.get("phone"));
 
-        if (f.equals("id") || f.endsWith("id"))
-            return Optional.ofNullable(fieldGenerators.get("id"));
+            case "city":
+                return Optional.ofNullable(fieldGenerators.get("city"));
 
-        if (f.contains("name"))
-            return Optional.ofNullable(fieldGenerators.get("name"));
+            case "state":
+                return Optional.ofNullable(fieldGenerators.get("state"));
 
-        if (f.contains("city"))
-            return Optional.ofNullable(fieldGenerators.get("city"));
+            case "country":
+                return Optional.ofNullable(fieldGenerators.get("country"));
 
-        if (f.contains("state"))
-            return Optional.ofNullable(fieldGenerators.get("state"));
+            case "zipcode":
+                return Optional.ofNullable(fieldGenerators.get("zipCode"));
 
-        if (f.contains("country"))
-            return Optional.ofNullable(fieldGenerators.get("country"));
+            case "company":
+                return Optional.ofNullable(fieldGenerators.get("company"));
 
-        if (f.contains("zipcode"))
-            return Optional.ofNullable(fieldGenerators.get("zipCode"));
+            case "title":
+                return Optional.ofNullable(fieldGenerators.get("title"));
 
-        if (f.contains("company"))
-            return Optional.ofNullable(fieldGenerators.get("company"));
+            case "createdat":
+                return Optional.ofNullable(fieldGenerators.get("createdAt"));
 
-        if (f.contains("title"))
-            return Optional.ofNullable(fieldGenerators.get("title"));
+            case "updatedat":
+                return Optional.ofNullable(fieldGenerators.get("updatedAt"));
 
-        if (f.contains("createdat"))
-            return Optional.ofNullable(fieldGenerators.get("createdAt"));
+            case "uuid":
+                return Optional.ofNullable(fieldGenerators.get("uuid"));
 
-        if (f.contains("updatedat"))
-            return Optional.ofNullable(fieldGenerators.get("updatedAt"));
+            case "url":
+                return Optional.ofNullable(fieldGenerators.get("url"));
 
-        return Optional.empty();
+            default:
+                return Optional.empty();
+        }
     }
-    /**
-     * Resolve generator based on type or throw clear error
-     */
+
     /**
      * Type-based generator with ENUM support
      */
-    private Supplier<Object> resolveTypeGenerator(String type, List<?> enumValues) {
+    private Supplier<Object> resolveTypeGenerator(
+            String type,
+            List<?> enumValues
+    ) {
 
         if ("enum".equals(type)) {
 
@@ -191,11 +245,13 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
             }
 
             return () -> enumValues.get(
-                    ThreadLocalRandom.current().nextInt(enumValues.size())
+                    ThreadLocalRandom.current()
+                            .nextInt(enumValues.size())
             );
         }
 
-        Supplier<Object> generator = typeGenerators.get(type);
+        Supplier<Object> generator =
+                typeGenerators.get(type);
 
         if (generator == null) {
             throw new IllegalArgumentException(
@@ -207,7 +263,11 @@ public class MockAutoGenerateServiceImpl implements MockAutoGenerateService {
     }
 
     /**
-     * Internal record for parsed schema
+     * Internal parsed schema holder
      */
-    private record ParsedSchema(String type, List<?> enumValues) {}
+    private record ParsedSchema(
+            String type,
+            List<?> enumValues
+    ) {
+    }
 }

--- a/src/main/java/com/mockify/backend/service/impl/MockRecordServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockRecordServiceImpl.java
@@ -11,6 +11,7 @@ import com.mockify.backend.model.MockRecord;
 import com.mockify.backend.model.MockSchema;
 import com.mockify.backend.repository.MockRecordRepository;
 import com.mockify.backend.repository.MockSchemaRepository;
+import com.mockify.backend.service.MockAutoGenerateService;
 import com.mockify.backend.service.MockRecordService;
 import com.mockify.backend.service.MockValidatorService;
 import lombok.RequiredArgsConstructor;
@@ -22,8 +23,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.UUID;
 
 @Service
@@ -35,22 +35,27 @@ public class MockRecordServiceImpl implements MockRecordService {
     private final MockSchemaRepository mockSchemaRepository;
     private final MockRecordMapper mockRecordMapper;
     private final MockValidatorService mockValidatorService;
+    private final MockAutoGenerateService autoGenerateService;
+
+    // -------------------------------------------------------------------------
+    // CREATE
+    // -------------------------------------------------------------------------
 
     @Override
     @Transactional
     @PreAuthorize("hasPermission(#schemaId, 'SCHEMA', 'RECORD:WRITE')")
     public MockRecordResponse createRecord(UUID userId, UUID schemaId, CreateMockRecordRequest request) {
-        if (request == null)           throw new BadRequestException("Request cannot be null");
-        if (schemaId == null)          throw new BadRequestException("Schema ID is required");
+
+        if (request == null) throw new BadRequestException("Request cannot be null");
+        if (schemaId == null) throw new BadRequestException("Schema ID is required");
         if (request.getData() == null) throw new BadRequestException("Record data cannot be null");
 
-        MockSchema schema = mockSchemaRepository.findById(schemaId)
-                .orElseThrow(() -> new ResourceNotFoundException("Schema not found"));
+        MockSchema schema = getSchemaOrThrow(schemaId);
 
-        // VALIDATE DATA
         mockValidatorService.validateRecordAgainstSchema(schema.getSchemaJson(), request.getData());
 
         MockRecordResponse response = persistRecord(schema, request);
+
         log.info("Record created in schema {} by user {}", schemaId, userId);
         return response;
     }
@@ -59,35 +64,79 @@ public class MockRecordServiceImpl implements MockRecordService {
     @Transactional
     @PreAuthorize("hasPermission(#schemaId, 'SCHEMA', 'RECORD:WRITE')")
     public List<MockRecordResponse> createRecordsBulk(UUID userId, UUID schemaId, List<CreateMockRecordRequest> requests) {
-        log.info("Bulk create requested by userId={} count={}", userId, requests == null ? 0 : requests.size());
-        if (requests == null || requests.isEmpty())
-            throw new BadRequestException("Records list cannot be null or empty");
 
-        // @PreAuthorize already fired once for the whole batch.
-        // IMPORTANT: we call persistRecord() directly, NOT createRecord().
-        MockSchema schema = mockSchemaRepository.findById(schemaId)
-                .orElseThrow(() -> new ResourceNotFoundException("Schema not found"));
+        if (requests == null || requests.isEmpty()) {
+            throw new BadRequestException("Records list cannot be null or empty");
+        }
+
+        MockSchema schema = getSchemaOrThrow(schemaId);
 
         log.info("Bulk creating {} records in schema {} by user {}", requests.size(), schemaId, userId);
 
         return requests.stream()
                 .map(req -> {
-                    if (req == null || req.getData() == null)
+                    if (req == null || req.getData() == null) {
                         throw new BadRequestException("Record data cannot be null");
-                    mockValidatorService.validateRecordAgainstSchema(schema.getSchemaJson(), req.getData());
+                    }
+
+                    mockValidatorService.validateRecordAgainstSchema(
+                            schema.getSchemaJson(), req.getData());
+
                     return persistRecord(schema, req);
                 })
                 .toList();
     }
 
+    // -------------------------------------------------------------------------
+    // AUTO GENERATE
+    // -------------------------------------------------------------------------
+
+    @Override
+    @Transactional
+    @PreAuthorize("hasPermission(#schemaId, 'SCHEMA', 'RECORD:WRITE')")
+    public List<MockRecordResponse> autoGenerateRecordsBulk(UUID userId, UUID schemaId, int count) {
+
+        if (count <= 0) {
+            throw new BadRequestException("Count must be greater than 0");
+        }
+
+        MockSchema schema = getSchemaOrThrow(schemaId);
+        Map<String, Object> schemaJson = schema.getSchemaJson();
+
+        // Validate schema once
+        mockValidatorService.validateSchemaDefinition(schemaJson);
+
+        log.info("Auto-generating {} records for schema {} by user {}", count, schemaId, userId);
+
+        List<CreateMockRecordRequest> requests = new ArrayList<>();
+
+        for (int i = 0; i < count; i++) {
+
+            Map<String, Object> record =
+                    autoGenerateService.generateRecord(schemaJson);
+
+            // Validate generated record
+            mockValidatorService.validateRecordAgainstSchema(schemaJson, record);
+
+            CreateMockRecordRequest req = new CreateMockRecordRequest();
+            req.setData(record);
+
+            requests.add(req);
+        }
+
+        return createRecordsBulk(userId, schemaId, requests);
+    }
+
+    // -------------------------------------------------------------------------
+    // READ
+    // -------------------------------------------------------------------------
+
     @Override
     @Transactional(readOnly = true)
     @PreAuthorize("hasPermission(#recordId, 'RECORD', 'READ')")
     public MockRecordResponse getRecordById(UUID userId, UUID recordId) {
-        log.debug("Fetching record for userId={}, recordId={}", userId, recordId);
 
-        MockRecord record = mockRecordRepository.findById(recordId)
-                .orElseThrow(() -> new ResourceNotFoundException("Record not found"));
+        MockRecord record = getRecordOrThrow(recordId);
         return mockRecordMapper.toResponse(record);
     }
 
@@ -96,38 +145,34 @@ public class MockRecordServiceImpl implements MockRecordService {
     @PreAuthorize("hasPermission(#schemaId, 'SCHEMA', 'RECORD:READ')")
     public Page<MockRecordResponse> getRecordsBySchemaId(UUID userId, UUID schemaId, Pageable pageable) {
 
-        log.debug("Fetching records for userId={}, schemaId={}", userId, schemaId);
-
-        // Validate Page size, protect from abuse
         PageableValidator.validate(pageable, 50);
 
-        Page<MockRecord> recordsPage = mockRecordRepository.findByMockSchema_Id(schemaId, pageable);
+        Page<MockRecord> page =
+                mockRecordRepository.findByMockSchema_Id(schemaId, pageable);
 
-        log.info("User {} fetching records page={}, size={} under schema {}",
-                userId,
-                recordsPage.getNumber(),
-                recordsPage.getSize(),
-                schemaId);
-
-        return recordsPage.map(mockRecordMapper::toResponse);
+        return page.map(mockRecordMapper::toResponse);
     }
+
+    // -------------------------------------------------------------------------
+    // UPDATE
+    // -------------------------------------------------------------------------
 
     @Override
     @Transactional
     @PreAuthorize("hasPermission(#recordId, 'RECORD', 'WRITE')")
     public MockRecordResponse updateRecord(UUID userId, UUID recordId, UpdateMockRecordRequest request) {
-        log.info("Updating record userId={}, recordId={}", userId, recordId);
 
         if (request == null) {
             throw new BadRequestException("Request cannot be null");
         }
 
-        MockRecord record = mockRecordRepository.findById(recordId)
-                .orElseThrow(() -> new ResourceNotFoundException("Record not found"));
+        MockRecord record = getRecordOrThrow(recordId);
 
         if (request.getData() != null) {
             mockValidatorService.validateRecordAgainstSchema(
-                    record.getMockSchema().getSchemaJson(), request.getData());
+                    record.getMockSchema().getSchemaJson(),
+                    request.getData()
+            );
         }
 
         mockRecordMapper.updateEntityFromRequest(request, record);
@@ -137,23 +182,58 @@ public class MockRecordServiceImpl implements MockRecordService {
         return mockRecordMapper.toResponse(record);
     }
 
+    // -------------------------------------------------------------------------
+    // DELETE
+    // -------------------------------------------------------------------------
+
     @Override
     @Transactional
     @PreAuthorize("hasPermission(#recordId, 'RECORD', 'DELETE')")
     public void deleteRecord(UUID userId, UUID recordId) {
-        log.warn("Deleting record userId={}, recordId={}", userId, recordId);
 
-        MockRecord record = mockRecordRepository.findById(recordId)
-                .orElseThrow(() -> new ResourceNotFoundException("Record not found"));
-        log.warn("Record {} deleted by user {}", recordId, userId);
+        MockRecord record = getRecordOrThrow(recordId);
         mockRecordRepository.delete(record);
+
+        log.warn("Record {} deleted by user {}", recordId, userId);
     }
+
+    // -------------------------------------------------------------------------
+    // INTERNAL HELPERS
+    // -------------------------------------------------------------------------
+
+    private MockSchema getSchemaOrThrow(UUID schemaId) {
+        return mockSchemaRepository.findById(schemaId)
+                .orElseThrow(() -> new ResourceNotFoundException("Schema not found"));
+    }
+
+    private MockRecord getRecordOrThrow(UUID recordId) {
+        return mockRecordRepository.findById(recordId)
+                .orElseThrow(() -> new ResourceNotFoundException("Record not found"));
+    }
+
+    private MockRecordResponse persistRecord(MockSchema schema, CreateMockRecordRequest request) {
+
+        MockRecord record = mockRecordMapper.toEntity(request);
+        record.setMockSchema(schema);
+        record.setCreatedAt(LocalDateTime.now());
+        record.setExpiresAt(LocalDateTime.now().plusDays(7));
+
+        mockRecordRepository.save(record);
+
+        return mockRecordMapper.toResponse(record);
+    }
+
+    // -------------------------------------------------------------------------
+    // OPTIONAL: CLEANUP JOB
+    // -------------------------------------------------------------------------
 
     @Transactional
     void deleteExpiredRecords() {
-        log.info("Deleting expired records...");
-        List<MockRecord> expired = mockRecordRepository.findByExpiresAtBefore(LocalDateTime.now());
+        List<MockRecord> expired =
+                mockRecordRepository.findByExpiresAtBefore(LocalDateTime.now());
+
         mockRecordRepository.deleteAll(expired);
+
         log.info("Expired records deleted count={}", expired.size());
     }
 
@@ -161,26 +241,5 @@ public class MockRecordServiceImpl implements MockRecordService {
     @Transactional(readOnly = true)
     public long countRecords() {
         return mockRecordRepository.count();
-    }
-
-    // -------------------------------------------------------------------------
-    // Private helpers
-    // -------------------------------------------------------------------------
-
-    /**
-     * Persists a single record against an already-loaded and already-authorised
-     * schema. private so it can be called by both {@link #createRecord}
-     * and {@link #createRecordsBulk} only
-     *
-     * <p>Do NOT annotate this method with {@code @PreAuthorize} — callers are
-     * responsible for ensuring authorisation has already been verified.</p>
-     */
-    private MockRecordResponse persistRecord(MockSchema schema, CreateMockRecordRequest request) {
-        MockRecord record = mockRecordMapper.toEntity(request);
-        record.setMockSchema(schema);
-        record.setCreatedAt(LocalDateTime.now());
-        record.setExpiresAt(LocalDateTime.now().plusDays(7));
-        mockRecordRepository.save(record);
-        return mockRecordMapper.toResponse(record);
     }
 }

--- a/src/main/java/com/mockify/backend/service/impl/MockRecordServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockRecordServiceImpl.java
@@ -24,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.*;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -37,25 +36,21 @@ public class MockRecordServiceImpl implements MockRecordService {
     private final MockValidatorService mockValidatorService;
     private final MockAutoGenerateService autoGenerateService;
 
-    // -------------------------------------------------------------------------
-    // CREATE
-    // -------------------------------------------------------------------------
-
     @Override
     @Transactional
     @PreAuthorize("hasPermission(#schemaId, 'SCHEMA', 'RECORD:WRITE')")
     public MockRecordResponse createRecord(UUID userId, UUID schemaId, CreateMockRecordRequest request) {
-
-        if (request == null) throw new BadRequestException("Request cannot be null");
-        if (schemaId == null) throw new BadRequestException("Schema ID is required");
+        if (request == null)           throw new BadRequestException("Request cannot be null");
+        if (schemaId == null)          throw new BadRequestException("Schema ID is required");
         if (request.getData() == null) throw new BadRequestException("Record data cannot be null");
 
-        MockSchema schema = getSchemaOrThrow(schemaId);
+        MockSchema schema = mockSchemaRepository.findById(schemaId)
+                .orElseThrow(() -> new ResourceNotFoundException("Schema not found"));
 
+        // VALIDATE DATA
         mockValidatorService.validateRecordAgainstSchema(schema.getSchemaJson(), request.getData());
 
         MockRecordResponse response = persistRecord(schema, request);
-
         log.info("Record created in schema {} by user {}", schemaId, userId);
         return response;
     }
@@ -64,20 +59,22 @@ public class MockRecordServiceImpl implements MockRecordService {
     @Transactional
     @PreAuthorize("hasPermission(#schemaId, 'SCHEMA', 'RECORD:WRITE')")
     public List<MockRecordResponse> createRecordsBulk(UUID userId, UUID schemaId, List<CreateMockRecordRequest> requests) {
+        log.info("Bulk create requested by userId={} count={}", userId, requests == null ? 0 : requests.size());
 
-        if (requests == null || requests.isEmpty()) {
+        if (requests == null || requests.isEmpty())
             throw new BadRequestException("Records list cannot be null or empty");
-        }
 
-        MockSchema schema = getSchemaOrThrow(schemaId);
+        // @PreAuthorize already fired once for the whole batch.
+        // IMPORTANT: we call persistRecord() directly, NOT createRecord().
+        MockSchema schema = mockSchemaRepository.findById(schemaId)
+                .orElseThrow(() -> new ResourceNotFoundException("Schema not found"));
 
         log.info("Bulk creating {} records in schema {} by user {}", requests.size(), schemaId, userId);
 
         return requests.stream()
                 .map(req -> {
-                    if (req == null || req.getData() == null) {
+                    if (req == null || req.getData() == null)
                         throw new BadRequestException("Record data cannot be null");
-                    }
 
                     mockValidatorService.validateRecordAgainstSchema(
                             schema.getSchemaJson(), req.getData());
@@ -87,26 +84,24 @@ public class MockRecordServiceImpl implements MockRecordService {
                 .toList();
     }
 
-    // -------------------------------------------------------------------------
-    // AUTO GENERATE
-    // -------------------------------------------------------------------------
-
+    // Auto generate records
     @Override
     @Transactional
     @PreAuthorize("hasPermission(#schemaId, 'SCHEMA', 'RECORD:WRITE')")
     public List<MockRecordResponse> autoGenerateRecordsBulk(UUID userId, UUID schemaId, int count) {
 
-        if (count <= 0) {
-            throw new BadRequestException("Count must be greater than 0");
-        }
+        log.info("Auto-generate requested by userId={} count={}", userId, count);
 
-        MockSchema schema = getSchemaOrThrow(schemaId);
+        if (count <= 0)
+            throw new BadRequestException("Count must be greater than 0");
+
+        MockSchema schema = mockSchemaRepository.findById(schemaId)
+                .orElseThrow(() -> new ResourceNotFoundException("Schema not found"));
+
         Map<String, Object> schemaJson = schema.getSchemaJson();
 
-        // Validate schema once
+        // VALIDATE SCHEMA
         mockValidatorService.validateSchemaDefinition(schemaJson);
-
-        log.info("Auto-generating {} records for schema {} by user {}", count, schemaId, userId);
 
         List<CreateMockRecordRequest> requests = new ArrayList<>();
 
@@ -115,28 +110,28 @@ public class MockRecordServiceImpl implements MockRecordService {
             Map<String, Object> record =
                     autoGenerateService.generateRecord(schemaJson);
 
-            // Validate generated record
+            // VALIDATE GENERATED RECORD
             mockValidatorService.validateRecordAgainstSchema(schemaJson, record);
 
             CreateMockRecordRequest req = new CreateMockRecordRequest();
             req.setData(record);
-
             requests.add(req);
         }
 
+        log.info("Auto-generating {} records in schema {} by user {}", count, schemaId, userId);
+
         return createRecordsBulk(userId, schemaId, requests);
     }
-
-    // -------------------------------------------------------------------------
-    // READ
-    // -------------------------------------------------------------------------
 
     @Override
     @Transactional(readOnly = true)
     @PreAuthorize("hasPermission(#recordId, 'RECORD', 'READ')")
     public MockRecordResponse getRecordById(UUID userId, UUID recordId) {
+        log.debug("Fetching record for userId={}, recordId={}", userId, recordId);
 
-        MockRecord record = getRecordOrThrow(recordId);
+        MockRecord record = mockRecordRepository.findById(recordId)
+                .orElseThrow(() -> new ResourceNotFoundException("Record not found"));
+
         return mockRecordMapper.toResponse(record);
     }
 
@@ -145,34 +140,39 @@ public class MockRecordServiceImpl implements MockRecordService {
     @PreAuthorize("hasPermission(#schemaId, 'SCHEMA', 'RECORD:READ')")
     public Page<MockRecordResponse> getRecordsBySchemaId(UUID userId, UUID schemaId, Pageable pageable) {
 
+        log.debug("Fetching records for userId={}, schemaId={}", userId, schemaId);
+
         PageableValidator.validate(pageable, 50);
 
-        Page<MockRecord> page =
+        Page<MockRecord> recordsPage =
                 mockRecordRepository.findByMockSchema_Id(schemaId, pageable);
 
-        return page.map(mockRecordMapper::toResponse);
-    }
+        log.info("User {} fetching records page={}, size={} under schema {}",
+                userId,
+                recordsPage.getNumber(),
+                recordsPage.getSize(),
+                schemaId);
 
-    // -------------------------------------------------------------------------
-    // UPDATE
-    // -------------------------------------------------------------------------
+        return recordsPage.map(mockRecordMapper::toResponse);
+    }
 
     @Override
     @Transactional
     @PreAuthorize("hasPermission(#recordId, 'RECORD', 'WRITE')")
     public MockRecordResponse updateRecord(UUID userId, UUID recordId, UpdateMockRecordRequest request) {
+        log.info("Updating record userId={}, recordId={}", userId, recordId);
 
         if (request == null) {
             throw new BadRequestException("Request cannot be null");
         }
 
-        MockRecord record = getRecordOrThrow(recordId);
+        MockRecord record = mockRecordRepository.findById(recordId)
+                .orElseThrow(() -> new ResourceNotFoundException("Record not found"));
 
         if (request.getData() != null) {
             mockValidatorService.validateRecordAgainstSchema(
                     record.getMockSchema().getSchemaJson(),
-                    request.getData()
-            );
+                    request.getData());
         }
 
         mockRecordMapper.updateEntityFromRequest(request, record);
@@ -182,53 +182,22 @@ public class MockRecordServiceImpl implements MockRecordService {
         return mockRecordMapper.toResponse(record);
     }
 
-    // -------------------------------------------------------------------------
-    // DELETE
-    // -------------------------------------------------------------------------
-
     @Override
     @Transactional
     @PreAuthorize("hasPermission(#recordId, 'RECORD', 'DELETE')")
     public void deleteRecord(UUID userId, UUID recordId) {
+        log.warn("Deleting record userId={}, recordId={}", userId, recordId);
 
-        MockRecord record = getRecordOrThrow(recordId);
-        mockRecordRepository.delete(record);
+        MockRecord record = mockRecordRepository.findById(recordId)
+                .orElseThrow(() -> new ResourceNotFoundException("Record not found"));
 
         log.warn("Record {} deleted by user {}", recordId, userId);
+        mockRecordRepository.delete(record);
     }
-
-    // -------------------------------------------------------------------------
-    // INTERNAL HELPERS
-    // -------------------------------------------------------------------------
-
-    private MockSchema getSchemaOrThrow(UUID schemaId) {
-        return mockSchemaRepository.findById(schemaId)
-                .orElseThrow(() -> new ResourceNotFoundException("Schema not found"));
-    }
-
-    private MockRecord getRecordOrThrow(UUID recordId) {
-        return mockRecordRepository.findById(recordId)
-                .orElseThrow(() -> new ResourceNotFoundException("Record not found"));
-    }
-
-    private MockRecordResponse persistRecord(MockSchema schema, CreateMockRecordRequest request) {
-
-        MockRecord record = mockRecordMapper.toEntity(request);
-        record.setMockSchema(schema);
-        record.setCreatedAt(LocalDateTime.now());
-        record.setExpiresAt(LocalDateTime.now().plusDays(7));
-
-        mockRecordRepository.save(record);
-
-        return mockRecordMapper.toResponse(record);
-    }
-
-    // -------------------------------------------------------------------------
-    // OPTIONAL: CLEANUP JOB
-    // -------------------------------------------------------------------------
 
     @Transactional
     void deleteExpiredRecords() {
+        log.info("Deleting expired records...");
         List<MockRecord> expired =
                 mockRecordRepository.findByExpiresAtBefore(LocalDateTime.now());
 
@@ -241,5 +210,26 @@ public class MockRecordServiceImpl implements MockRecordService {
     @Transactional(readOnly = true)
     public long countRecords() {
         return mockRecordRepository.count();
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Persists a single record against an already-loaded and already-authorised
+     * schema. private so it can be called by both {@link #createRecord}
+     * and {@link #createRecordsBulk} only
+     *
+     * <p>Do NOT annotate this method with {@code @PreAuthorize} — callers are
+     * responsible for ensuring authorisation has already been verified.</p>
+     */
+    private MockRecordResponse persistRecord(MockSchema schema, CreateMockRecordRequest request) {
+        MockRecord record = mockRecordMapper.toEntity(request);
+        record.setMockSchema(schema);
+        record.setCreatedAt(LocalDateTime.now());
+        record.setExpiresAt(LocalDateTime.now().plusDays(7));
+        mockRecordRepository.save(record);
+        return mockRecordMapper.toResponse(record);
     }
 }

--- a/src/main/java/com/mockify/backend/service/impl/MockRecordServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockRecordServiceImpl.java
@@ -142,6 +142,7 @@ public class MockRecordServiceImpl implements MockRecordService {
 
         log.debug("Fetching records for userId={}, schemaId={}", userId, schemaId);
 
+        // Validate Page size, protect from abuse
         PageableValidator.validate(pageable, 50);
 
         Page<MockRecord> recordsPage =

--- a/src/main/java/com/mockify/backend/service/impl/MockRecordServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockRecordServiceImpl.java
@@ -94,6 +94,9 @@ public class MockRecordServiceImpl implements MockRecordService {
 
         if (count <= 0)
             throw new BadRequestException("Count must be greater than 0");
+        if (count > MAX_AUTO_GENERATE_COUNT)
+            throw new BadRequestException(
+                    "Count must not exceed " + MAX_AUTO_GENERATE_COUNT);
 
         MockSchema schema = mockSchemaRepository.findById(schemaId)
                 .orElseThrow(() -> new ResourceNotFoundException("Schema not found"));

--- a/src/main/java/com/mockify/backend/service/impl/MockRecordServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockRecordServiceImpl.java
@@ -65,23 +65,13 @@ public class MockRecordServiceImpl implements MockRecordService {
             throw new BadRequestException("Records list cannot be null or empty");
 
         // @PreAuthorize already fired once for the whole batch.
-        // IMPORTANT: we call persistRecord() directly, NOT createRecord().
+        // IMPORTANT: we call persistRecordsBulk() directly, NOT createRecord().
         MockSchema schema = mockSchemaRepository.findById(schemaId)
                 .orElseThrow(() -> new ResourceNotFoundException("Schema not found"));
 
         log.info("Bulk creating {} records in schema {} by user {}", requests.size(), schemaId, userId);
 
-        return requests.stream()
-                .map(req -> {
-                    if (req == null || req.getData() == null)
-                        throw new BadRequestException("Record data cannot be null");
-
-                    mockValidatorService.validateRecordAgainstSchema(
-                            schema.getSchemaJson(), req.getData());
-
-                    return persistRecord(schema, req);
-                })
-                .toList();
+        return persistRecordsBulk(schema, requests, true);
     }
 
     // Auto generate records
@@ -91,12 +81,6 @@ public class MockRecordServiceImpl implements MockRecordService {
     public List<MockRecordResponse> autoGenerateRecordsBulk(UUID userId, UUID schemaId, int count) {
 
         log.info("Auto-generate requested by userId={} count={}", userId, count);
-
-        if (count <= 0)
-            throw new BadRequestException("Count must be greater than 0");
-        if (count > MAX_AUTO_GENERATE_COUNT)
-            throw new BadRequestException(
-                    "Count must not exceed " + MAX_AUTO_GENERATE_COUNT);
 
         MockSchema schema = mockSchemaRepository.findById(schemaId)
                 .orElseThrow(() -> new ResourceNotFoundException("Schema not found"));
@@ -123,7 +107,7 @@ public class MockRecordServiceImpl implements MockRecordService {
 
         log.info("Auto-generating {} records in schema {} by user {}", count, schemaId, userId);
 
-        return createRecordsBulk(userId, schemaId, requests);
+        return persistRecordsBulk(schema, requests, false);
     }
 
     @Override
@@ -219,6 +203,38 @@ public class MockRecordServiceImpl implements MockRecordService {
     // -------------------------------------------------------------------------
     // Private helpers
     // -------------------------------------------------------------------------
+
+    /**
+     * Shared bulk persistence helper.
+     *
+     * <p>Do NOT annotate this method with {@code @PreAuthorize} — callers are
+     * responsible for ensuring authorisation has already been verified.</p>
+     */
+    private List<MockRecordResponse> persistRecordsBulk(
+            MockSchema schema,
+            List<CreateMockRecordRequest> requests,
+            boolean validate
+    ) {
+
+        Map<String, Object> schemaJson = schema.getSchemaJson();
+
+        return requests.stream()
+                .map(req -> {
+
+                    if (req == null || req.getData() == null)
+                        throw new BadRequestException("Record data cannot be null");
+
+                    if (validate) {
+                        mockValidatorService.validateRecordAgainstSchema(
+                                schemaJson,
+                                req.getData()
+                        );
+                    }
+
+                    return persistRecord(schema, req);
+                })
+                .toList();
+    }
 
     /**
      * Persists a single record against an already-loaded and already-authorised

--- a/src/main/java/com/mockify/backend/service/impl/MockValidatorServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockValidatorServiceImpl.java
@@ -5,6 +5,8 @@ import com.mockify.backend.service.MockValidatorService;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.springframework.stereotype.Service;
 
+import java.net.URI;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.*;
 
@@ -20,6 +22,7 @@ public class MockValidatorServiceImpl implements MockValidatorService {
 
     private enum ALLOWED_TYPES {
 
+
         STRING("string"),
         NUMBER("number"),
         BOOLEAN("boolean"),
@@ -27,10 +30,12 @@ public class MockValidatorServiceImpl implements MockValidatorService {
         OBJECT("object"),
         EMAIL("email"),
         UUID("uuid"),
+        DATE("date"),
         DATETIME("datetime"),
         NULL("null"),
         JSON("json"),
-        ENUM("enum");
+        ENUM("enum"),
+        URL("url");
 
         private final String value;
 
@@ -216,12 +221,39 @@ public class MockValidatorServiceImpl implements MockValidatorService {
                 }
                 break;
 
+
+            case DATE:
+                require(value instanceof String, field, "date");
+
+                try {
+                    LocalDate.parse(value.toString());
+                } catch (Exception e) {
+                    throw new BadRequestException(
+                            "Invalid date format (yyyy-MM-dd) for field '"
+                                    + field + "'"
+                    );
+                }
+                break;
+
             case DATETIME:
                 require(value instanceof String, field, "datetime");
                 try {
                     OffsetDateTime.parse(value.toString());
                 } catch (Exception e) {
                     throw new BadRequestException("Invalid datetime format (ISO-8601) for field '" + field + "'");
+                }
+                break;
+
+            case URL:
+                require(value instanceof String, field, "url");
+
+                try {
+                    new URI(value.toString());
+                } catch (Exception e) {
+                    throw new BadRequestException(
+                            "Invalid URL format for field '"
+                                    + field + "'"
+                    );
                 }
                 break;
 

--- a/src/test/java/com/mockify/backend/service/MockAutoGenerateServiceImplTest.java
+++ b/src/test/java/com/mockify/backend/service/MockAutoGenerateServiceImplTest.java
@@ -1,0 +1,226 @@
+package com.mockify.backend.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MockAutoGenerateServiceImplTest {
+
+    private MockAutoGenerateServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MockAutoGenerateServiceImpl();
+    }
+
+    @Test
+    void shouldGenerateRecordWithFieldGenerators() {
+
+        Map<String, Object> schema = Map.of(
+                "id", "number",
+                "name", "string",
+                "firstName", "string",
+                "lastName", "string",
+                "username", "string",
+                "email", "string"
+        );
+
+        Map<String, Object> result = service.generateRecord(schema);
+
+        assertNotNull(result);
+
+        assertTrue(result.get("id") instanceof Number);
+
+        assertAll(
+                () -> assertNotNull(result.get("name")),
+                () -> assertNotNull(result.get("firstName")),
+                () -> assertNotNull(result.get("lastName")),
+                () -> assertNotNull(result.get("username"))
+        );
+
+        assertTrue(
+                result.get("email")
+                        .toString()
+                        .contains("@")
+        );
+    }
+
+    @Test
+    void shouldGenerateRecordWithExtendedFieldGenerators() {
+
+        Map<String, Object> schema = Map.ofEntries(
+                Map.entry("phone", "string"),
+                Map.entry("city", "string"),
+                Map.entry("state", "string"),
+                Map.entry("country", "string"),
+                Map.entry("zipCode", "string"),
+                Map.entry("company", "string"),
+                Map.entry("title", "string"),
+                Map.entry("createdAt", "string"),
+                Map.entry("updatedAt", "string"),
+                Map.entry("uuid", "string"),
+                Map.entry("url", "string")
+        );
+
+        Map<String, Object> result = service.generateRecord(schema);
+
+        assertNotNull(result);
+
+        assertAll(
+                () -> assertNotNull(result.get("phone")),
+                () -> assertNotNull(result.get("city")),
+                () -> assertNotNull(result.get("state")),
+                () -> assertNotNull(result.get("country")),
+                () -> assertNotNull(result.get("zipCode")),
+                () -> assertNotNull(result.get("company")),
+                () -> assertNotNull(result.get("title")),
+                () -> assertNotNull(result.get("createdAt")),
+                () -> assertNotNull(result.get("updatedAt"))
+        );
+
+        assertDoesNotThrow(() ->
+                UUID.fromString(result.get("uuid").toString())
+        );
+
+        String url = result.get("url").toString();
+
+        assertAll(
+                () -> assertNotNull(url),
+                () -> assertFalse(url.isBlank()),
+                () -> assertTrue(url.contains("."))
+        );
+    }
+
+    @Test
+    void shouldGenerateRecordWithTypeGenerators() {
+
+        Map<String, Object> schema = Map.of(
+                "description", "string",
+                "age", "number",
+                "active", "boolean",
+                "birthDate", "date",
+                "eventTime", "date-time",
+                "tags", "array",
+                "metadata", "object"
+        );
+
+        Map<String, Object> result = service.generateRecord(schema);
+
+        assertNotNull(result);
+
+        assertAll(
+                () -> assertTrue(result.get("description") instanceof String),
+                () -> assertTrue(result.get("age") instanceof Number),
+                () -> assertTrue(result.get("active") instanceof Boolean),
+                () -> assertTrue(result.get("birthDate") instanceof String),
+                () -> assertTrue(result.get("eventTime") instanceof String),
+                () -> assertTrue(result.get("tags") instanceof List),
+                () -> assertTrue(result.get("metadata") instanceof Map)
+        );
+    }
+
+    @Test
+    void shouldGenerateEnumValue() {
+
+        List<String> allowedStatuses = List.of(
+                "ACTIVE",
+                "INACTIVE",
+                "PENDING"
+        );
+
+        Map<String, Object> schema = Map.of(
+                "status", Map.of(
+                        "type", "enum",
+                        "values", allowedStatuses
+                )
+        );
+
+        Map<String, Object> result = service.generateRecord(schema);
+
+        assertTrue(
+                allowedStatuses.contains(result.get("status"))
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionForUnsupportedType() {
+
+        Map<String, Object> schema = Map.of(
+                "salary", "decimal"
+        );
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> service.generateRecord(schema)
+        );
+
+        assertEquals(
+                "Unsupported field type: decimal",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionForInvalidSchemaFormat() {
+
+        Map<String, Object> schema = Map.of(
+                "field", 123
+        );
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> service.generateRecord(schema)
+        );
+
+        assertEquals(
+                "Invalid schema format for field: field",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTypeMissingInMapSchema() {
+
+        Map<String, Object> schema = Map.of(
+                "status", Map.of(
+                        "values", List.of("A", "B")
+                )
+        );
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> service.generateRecord(schema)
+        );
+
+        assertEquals(
+                "Missing or invalid 'type' for field: status",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionForEmptyEnumValues() {
+
+        Map<String, Object> schema = Map.of(
+                "status", Map.of(
+                        "type", "enum",
+                        "values", List.of()
+                )
+        );
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> service.generateRecord(schema)
+        );
+
+        assertEquals(
+                "ENUM type requires non-empty values list",
+                exception.getMessage()
+        );
+    }
+}

--- a/src/test/java/com/mockify/backend/service/MockRecordServiceImplTest.java
+++ b/src/test/java/com/mockify/backend/service/MockRecordServiceImplTest.java
@@ -1,0 +1,367 @@
+package com.mockify.backend.service.impl;
+
+import com.mockify.backend.dto.request.record.CreateMockRecordRequest;
+import com.mockify.backend.dto.request.record.UpdateMockRecordRequest;
+import com.mockify.backend.dto.response.record.MockRecordResponse;
+import com.mockify.backend.exception.BadRequestException;
+import com.mockify.backend.exception.ResourceNotFoundException;
+import com.mockify.backend.mapper.MockRecordMapper;
+import com.mockify.backend.model.MockRecord;
+import com.mockify.backend.model.MockSchema;
+import com.mockify.backend.repository.MockRecordRepository;
+import com.mockify.backend.repository.MockSchemaRepository;
+import com.mockify.backend.service.MockAutoGenerateService;
+import com.mockify.backend.service.MockValidatorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MockRecordServiceImplTest {
+
+    @Mock
+    private MockRecordRepository mockRecordRepository;
+
+    @Mock
+    private MockSchemaRepository mockSchemaRepository;
+
+    @Mock
+    private MockRecordMapper mockRecordMapper;
+
+    @Mock
+    private MockValidatorService mockValidatorService;
+
+    @Mock
+    private MockAutoGenerateService autoGenerateService;
+
+    @InjectMocks
+    private MockRecordServiceImpl mockRecordService;
+
+    private UUID userId;
+    private UUID schemaId;
+    private UUID recordId;
+
+    private MockSchema schema;
+    private MockRecord record;
+
+    private CreateMockRecordRequest createRequest;
+    private UpdateMockRecordRequest updateRequest;
+
+    private MockRecordResponse response;
+
+    private Map<String, Object> data;
+
+    @BeforeEach
+    void setUp() {
+
+        userId = UUID.randomUUID();
+        schemaId = UUID.randomUUID();
+        recordId = UUID.randomUUID();
+
+        data = new HashMap<>();
+        data.put("name", "John");
+
+        schema = new MockSchema();
+        schema.setId(schemaId);
+        schema.setSchemaJson(Map.of("type", "object"));
+
+        record = new MockRecord();
+        record.setId(recordId);
+        record.setMockSchema(schema);
+
+        createRequest = new CreateMockRecordRequest();
+        createRequest.setData(data);
+
+        updateRequest = new UpdateMockRecordRequest();
+        updateRequest.setData(data);
+
+        response = new MockRecordResponse();
+    }
+
+    // -------------------------------------------------------------------------
+    // createRecord
+    // -------------------------------------------------------------------------
+
+    @Test
+    void createRecord_ShouldCreateSuccessfully() {
+
+        when(mockSchemaRepository.findById(schemaId))
+                .thenReturn(Optional.of(schema));
+
+        when(mockRecordMapper.toEntity(createRequest))
+                .thenReturn(record);
+
+        when(mockRecordMapper.toResponse(record))
+                .thenReturn(response);
+
+        MockRecordResponse result =
+                mockRecordService.createRecord(userId, schemaId, createRequest);
+
+        assertNotNull(result);
+
+        verify(mockValidatorService)
+                .validateRecordAgainstSchema(schema.getSchemaJson(), data);
+
+        verify(mockRecordRepository).save(record);
+    }
+
+    @Test
+    void createRecord_ShouldThrow_WhenRequestNull() {
+
+        assertThrows(
+                BadRequestException.class,
+                () -> mockRecordService.createRecord(userId, schemaId, null)
+        );
+    }
+
+    @Test
+    void createRecord_ShouldThrow_WhenSchemaNotFound() {
+
+        when(mockSchemaRepository.findById(schemaId))
+                .thenReturn(Optional.empty());
+
+        assertThrows(
+                ResourceNotFoundException.class,
+                () -> mockRecordService.createRecord(userId, schemaId, createRequest)
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // createRecordsBulk
+    // -------------------------------------------------------------------------
+
+    @Test
+    void createRecordsBulk_ShouldCreateSuccessfully() {
+
+        List<CreateMockRecordRequest> requests = List.of(createRequest);
+
+        when(mockSchemaRepository.findById(schemaId))
+                .thenReturn(Optional.of(schema));
+
+        when(mockRecordMapper.toEntity(any()))
+                .thenReturn(record);
+
+        when(mockRecordMapper.toResponse(any()))
+                .thenReturn(response);
+
+        List<MockRecordResponse> result =
+                mockRecordService.createRecordsBulk(userId, schemaId, requests);
+
+        assertEquals(1, result.size());
+
+        verify(mockRecordRepository, times(1)).save(any());
+    }
+
+    @Test
+    void createRecordsBulk_ShouldThrow_WhenEmptyList() {
+
+        assertThrows(
+                BadRequestException.class,
+                () -> mockRecordService.createRecordsBulk(
+                        userId,
+                        schemaId,
+                        Collections.emptyList()
+                )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // autoGenerateRecordsBulk
+    // -------------------------------------------------------------------------
+
+    @Test
+    void autoGenerateRecordsBulk_ShouldGenerateSuccessfully() {
+
+        when(mockSchemaRepository.findById(schemaId))
+                .thenReturn(Optional.of(schema));
+
+        when(autoGenerateService.generateRecord(any()))
+                .thenReturn(data);
+
+        when(mockRecordMapper.toEntity(any()))
+                .thenReturn(record);
+
+        when(mockRecordMapper.toResponse(any()))
+                .thenReturn(response);
+
+        List<MockRecordResponse> result =
+                mockRecordService.autoGenerateRecordsBulk(userId, schemaId, 2);
+
+        assertEquals(2, result.size());
+
+        verify(autoGenerateService, times(2))
+                .generateRecord(any());
+
+        verify(mockRecordRepository, times(2))
+                .save(any());
+    }
+
+    // -------------------------------------------------------------------------
+    // getRecordById
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getRecordById_ShouldReturnRecord() {
+
+        when(mockRecordRepository.findById(recordId))
+                .thenReturn(Optional.of(record));
+
+        when(mockRecordMapper.toResponse(record))
+                .thenReturn(response);
+
+        MockRecordResponse result =
+                mockRecordService.getRecordById(userId, recordId);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void getRecordById_ShouldThrow_WhenNotFound() {
+
+        when(mockRecordRepository.findById(recordId))
+                .thenReturn(Optional.empty());
+
+        assertThrows(
+                ResourceNotFoundException.class,
+                () -> mockRecordService.getRecordById(userId, recordId)
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // getRecordsBySchemaId
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getRecordsBySchemaId_ShouldReturnPage() {
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<MockRecord> page =
+                new PageImpl<>(List.of(record));
+
+        when(mockRecordRepository.findByMockSchema_Id(schemaId, pageable))
+                .thenReturn(page);
+
+        when(mockRecordMapper.toResponse(any()))
+                .thenReturn(response);
+
+        Page<MockRecordResponse> result =
+                mockRecordService.getRecordsBySchemaId(userId, schemaId, pageable);
+
+        assertEquals(1, result.getTotalElements());
+    }
+
+    // -------------------------------------------------------------------------
+    // updateRecord
+    // -------------------------------------------------------------------------
+
+    @Test
+    void updateRecord_ShouldUpdateSuccessfully() {
+
+        when(mockRecordRepository.findById(recordId))
+                .thenReturn(Optional.of(record));
+
+        when(mockRecordMapper.toResponse(record))
+                .thenReturn(response);
+
+        MockRecordResponse result =
+                mockRecordService.updateRecord(userId, recordId, updateRequest);
+
+        assertNotNull(result);
+
+        verify(mockValidatorService)
+                .validateRecordAgainstSchema(
+                        schema.getSchemaJson(),
+                        data
+                );
+
+        verify(mockRecordMapper)
+                .updateEntityFromRequest(updateRequest, record);
+
+        verify(mockRecordRepository)
+                .save(record);
+    }
+
+    @Test
+    void updateRecord_ShouldThrow_WhenRequestNull() {
+
+        assertThrows(
+                BadRequestException.class,
+                () -> mockRecordService.updateRecord(userId, recordId, null)
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // deleteRecord
+    // -------------------------------------------------------------------------
+
+    @Test
+    void deleteRecord_ShouldDeleteSuccessfully() {
+
+        when(mockRecordRepository.findById(recordId))
+                .thenReturn(Optional.of(record));
+
+        mockRecordService.deleteRecord(userId, recordId);
+
+        verify(mockRecordRepository).delete(record);
+    }
+
+    @Test
+    void deleteRecord_ShouldThrow_WhenNotFound() {
+
+        when(mockRecordRepository.findById(recordId))
+                .thenReturn(Optional.empty());
+
+        assertThrows(
+                ResourceNotFoundException.class,
+                () -> mockRecordService.deleteRecord(userId, recordId)
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // countRecords
+    // -------------------------------------------------------------------------
+
+    @Test
+    void countRecords_ShouldReturnCount() {
+
+        when(mockRecordRepository.count())
+                .thenReturn(5L);
+
+        long result = mockRecordService.countRecords();
+
+        assertEquals(5L, result);
+    }
+
+    // -------------------------------------------------------------------------
+    // deleteExpiredRecords
+    // -------------------------------------------------------------------------
+
+    @Test
+    void deleteExpiredRecords_ShouldDeleteExpiredRecords() throws Exception {
+
+        List<MockRecord> expired = List.of(record);
+
+        when(mockRecordRepository.findByExpiresAtBefore(any(LocalDateTime.class)))
+                .thenReturn(expired);
+
+        Method method = MockRecordServiceImpl.class
+                .getDeclaredMethod("deleteExpiredRecords");
+
+        method.setAccessible(true);
+        method.invoke(mockRecordService);
+
+        verify(mockRecordRepository).deleteAll(expired);
+    }
+}


### PR DESCRIPTION

####  Summary

This PR introduces **automatic mock data generation** for schemas in Mockify. Users can now generate multiple mock records automatically based on their schema definitions, enabling faster API testing without manually providing record data.

---

#### Key Changes

* **Added auto-generation endpoint**

  * `POST /api/{org}/{project}/{schema}/records/auto-bulk`
  * Allows users to generate mock records by specifying a `count`.

* **Implemented `MockAutoGenerateService`**

  * Generates mock records dynamically using **Java Faker**.
  * Supports schema-driven generation based on field types.

* **Field-aware data generation**

  * Introduced a **field-based generation strategy** before falling back to type-based generation.
  * Examples:

    * `email` → realistic email address
    * `username` → username
    * `id` → numeric identifier

* **Fallback type-based generators**

  * `string` → lorem word
  * `number` → random number
  * `boolean` → true/false
  * `array` → sample list
  * `object` → simple key-value object

* **Reusable pipeline**

  * Auto-generated records are converted to `CreateMockRecordRequest` objects and processed through the existing `createRecordsBulk()` method.
  * Ensures validation, security checks, and persistence remain consistent with manual record creation.

---

#### Architecture Improvements

* Introduced **generator maps** (`Map<String, Supplier<Object>>`) to avoid large `if-else` logic.
* Clear separation between:

  * **field-based generation rules**
  * **type-based fallback generators**
* Maintains extensibility for adding new generation strategies.

---

#### Example

Schema:

```json
{
  "id": "number",
  "username": "string",
  "email": "string",
  "isActive": "boolean"
}
```

Generated record:

```json
{
  "id": 48321,
  "username": "john_doe21",
  "email": "john.doe@gmail.com",
  "isActive": true
}
```

---

#### Testing

Tested via **Swagger UI**:

```
POST /api/{org}/{project}/{schema}/records/auto-bulk
Body:
{
  "count": 5
}
```

Verified:

* Records generated according to schema
* Validation pipeline reused
* Records persisted correctly
* API responses match manual bulk creation format

---

#### Future Improvements

* Support nested object schemas
* Typed arrays and deeper object generation
* Schema hints (`format: email`, `min`, `max`, etc.)
* Deterministic mock generation using seeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk auto-generation of mock records (1–1000 per request) with schema validation
  * Intelligent field recognition and type-based value generation for more realistic mock data

* **Chores**
  * Updated build to include a data generation library dependency

* **Tests**
  * Added unit tests covering auto-generation, validation, and record service behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sadabazhar/mockify-backend/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->