### PR TITLE
Team collaboration — org membership, workspace roles and invitations

### DIFF
--- a/src/main/java/com/mockify/backend/common/enums/MemberRole.java
+++ b/src/main/java/com/mockify/backend/common/enums/MemberRole.java
@@ -1,0 +1,25 @@
+package com.mockify.backend.common.enums;
+
+public enum MemberRole {
+    VIEWER,
+    DEVELOPER,
+    ADMIN,
+    OWNER;
+
+    /** True if this role can manage (invite/remove/change role of) a member with targetRole. */
+    public boolean canManage(MemberRole target) {
+        if (target == OWNER) return false;
+        return ordinal() >= ADMIN.ordinal() && ordinal() > target.ordinal();
+    }
+
+    /** True if this role can invite someone at inviteeRole. */
+    public boolean canInviteAs(MemberRole inviteeRole) {
+        if (inviteeRole == OWNER) return false;
+        return ordinal() >= ADMIN.ordinal() && ordinal() > inviteeRole.ordinal();
+    }
+
+    /** True if this role satisfies the minimum required role. */
+    public boolean atLeast(MemberRole minimum) {
+        return ordinal() >= minimum.ordinal();
+    }
+}

--- a/src/main/java/com/mockify/backend/common/enums/MemberRole.java
+++ b/src/main/java/com/mockify/backend/common/enums/MemberRole.java
@@ -1,25 +1,35 @@
 package com.mockify.backend.common.enums;
 
 public enum MemberRole {
-    VIEWER,
-    DEVELOPER,
-    ADMIN,
-    OWNER;
+    VIEWER(0),
+    DEVELOPER(1),
+    ADMIN(2),
+    OWNER(3);
+
+    private final int level;
+
+    MemberRole(int level) {
+        this.level = level;
+    }
+
+    /** True if this role satisfies the minimum required role. */
+    public boolean atLeast(MemberRole other) {
+        return this.level >= other.level;
+    }
+
+    public boolean higherThan(MemberRole other) {
+        return this.level > other.level;
+    }
 
     /** True if this role can manage (invite/remove/change role of) a member with targetRole. */
     public boolean canManage(MemberRole target) {
         if (target == OWNER) return false;
-        return ordinal() >= ADMIN.ordinal() && ordinal() > target.ordinal();
+        return this.atLeast(ADMIN) && this.higherThan(target);
     }
 
     /** True if this role can invite someone at inviteeRole. */
     public boolean canInviteAs(MemberRole inviteeRole) {
         if (inviteeRole == OWNER) return false;
-        return ordinal() >= ADMIN.ordinal() && ordinal() > inviteeRole.ordinal();
-    }
-
-    /** True if this role satisfies the minimum required role. */
-    public boolean atLeast(MemberRole minimum) {
-        return ordinal() >= minimum.ordinal();
+        return this.atLeast(ADMIN) && this.higherThan(inviteeRole);
     }
 }

--- a/src/main/java/com/mockify/backend/config/OpenApiConfig.java
+++ b/src/main/java/com/mockify/backend/config/OpenApiConfig.java
@@ -48,6 +48,8 @@ public class OpenApiConfig {
                         new Tag().name("Authentication").description("User authentication and authorization operations including registration, login, logout, token refresh, and current user retrieval."),
                         new Tag().name("Dashboard").description("Provides summary statistics and health insights for users, organizations, projects, and schemas."),
                         new Tag().name("Organization").description("Operations for managing organizations and their associated resources."),
+                        new Tag().name("Organization Members").description("Team membership, invitations, and role management."),
+                        new Tag().name("Invitations").description("Accept organization invitations via token-based onboarding."),
                         new Tag().name("Project").description("Operations for managing the project lifecycle and related resources."),
                         new Tag().name("Mock Schema Templates").description("Operation for Getting Pre Defined Schema Templates."),
                         new Tag().name("Mock Schema").description("Operations for defining and managing mock data schemas."),

--- a/src/main/java/com/mockify/backend/controller/InvitationController.java
+++ b/src/main/java/com/mockify/backend/controller/InvitationController.java
@@ -3,9 +3,11 @@ package com.mockify.backend.controller;
 import com.mockify.backend.security.SecurityUtils;
 import com.mockify.backend.service.OrganizationMemberService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -13,15 +15,18 @@ import java.util.UUID;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/invitations")
-@Tag(name = "Organization Members",  description = "Accept organization invitations via token-based onboarding.")
+@Tag(name = "Invitations",
+        description = "Accept organization invitations via token-based onboarding.")
+@Validated
 public class InvitationController {
 
     private final OrganizationMemberService memberService;
 
     @PostMapping("/accept")
     public ResponseEntity<Void> acceptInvitation(
-            @RequestParam String token,
+            @RequestParam @NotBlank(message = "Token is required") String token,
             Authentication auth) {
+        SecurityUtils.requireJwtAuthentication(auth);
         UUID userId = SecurityUtils.resolveUserId(auth);
         memberService.acceptInvitation(token, userId);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/mockify/backend/controller/InvitationController.java
+++ b/src/main/java/com/mockify/backend/controller/InvitationController.java
@@ -1,0 +1,29 @@
+package com.mockify.backend.controller;
+
+import com.mockify.backend.security.SecurityUtils;
+import com.mockify.backend.service.OrganizationMemberService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/invitations")
+@Tag(name = "Organization Members",  description = "Accept organization invitations via token-based onboarding.")
+public class InvitationController {
+
+    private final OrganizationMemberService memberService;
+
+    @PostMapping("/accept")
+    public ResponseEntity<Void> acceptInvitation(
+            @RequestParam String token,
+            Authentication auth) {
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        memberService.acceptInvitation(token, userId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/mockify/backend/controller/OrganizationMemberController.java
+++ b/src/main/java/com/mockify/backend/controller/OrganizationMemberController.java
@@ -1,0 +1,112 @@
+package com.mockify.backend.controller;
+
+import com.mockify.backend.dto.request.member.*;
+import com.mockify.backend.dto.response.member.*;
+import com.mockify.backend.security.SecurityUtils;
+import com.mockify.backend.service.EndpointService;
+import com.mockify.backend.service.OrganizationMemberService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/organizations/{org}/members")
+@Tag(name = "Organization Members", description = "Manage team membership and invitations")
+public class OrganizationMemberController {
+
+    private final OrganizationMemberService memberService;
+    private final EndpointService endpointService;
+
+    @GetMapping
+    public ResponseEntity<List<MemberResponse>> listMembers(
+            @PathVariable String org, Authentication auth) {
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        UUID orgId  = endpointService.resolveOrganization(org);
+        return ResponseEntity.ok(memberService.listMembers(userId, orgId));
+    }
+
+    @GetMapping("/invitations")
+    public ResponseEntity<List<InvitationResponse>> listInvitations(
+            @PathVariable String org, Authentication auth) {
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        UUID orgId  = endpointService.resolveOrganization(org);
+        return ResponseEntity.ok(memberService.listPendingInvitations(userId, orgId));
+    }
+
+    @PostMapping("/invite")
+    public ResponseEntity<Void> invite(
+            @PathVariable String org,
+            @Valid @RequestBody InviteMemberRequest request,
+            Authentication auth) {
+        SecurityUtils.requireJwtAuthentication(auth);
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        UUID orgId  = endpointService.resolveOrganization(org);
+        memberService.inviteMember(userId, orgId, request);
+        return ResponseEntity.accepted().build();
+    }
+
+    @DeleteMapping("/invitations/{invitationId}")
+    public ResponseEntity<Void> cancelInvitation(
+            @PathVariable String org,
+            @PathVariable UUID invitationId,
+            Authentication auth) {
+        SecurityUtils.requireJwtAuthentication(auth);
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        UUID orgId  = endpointService.resolveOrganization(org);
+        memberService.cancelInvitation(userId, orgId, invitationId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{targetUserId}/role")
+    public ResponseEntity<MemberResponse> changeMemberRole(
+            @PathVariable String org,
+            @PathVariable UUID targetUserId,
+            @Valid @RequestBody ChangeMemberRoleRequest request,
+            Authentication auth) {
+        SecurityUtils.requireJwtAuthentication(auth);
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        UUID orgId  = endpointService.resolveOrganization(org);
+        return ResponseEntity.ok(memberService.changeMemberRole(userId, orgId, targetUserId, request));
+    }
+
+    @DeleteMapping("/{targetUserId}")
+    public ResponseEntity<Void> removeMember(
+            @PathVariable String org,
+            @PathVariable UUID targetUserId,
+            Authentication auth) {
+        SecurityUtils.requireJwtAuthentication(auth);
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        UUID orgId  = endpointService.resolveOrganization(org);
+        memberService.removeMember(userId, orgId, targetUserId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/leave")
+    public ResponseEntity<Void> leaveOrganization(
+            @PathVariable String org, Authentication auth) {
+        SecurityUtils.requireJwtAuthentication(auth);
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        UUID orgId  = endpointService.resolveOrganization(org);
+        memberService.leaveOrganization(userId, orgId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/transfer-ownership")
+    public ResponseEntity<Void> transferOwnership(
+            @PathVariable String org,
+            @Valid @RequestBody TransferOwnershipRequest request,
+            Authentication auth) {
+        SecurityUtils.requireJwtAuthentication(auth);
+        UUID userId = SecurityUtils.resolveUserId(auth);
+        UUID orgId  = endpointService.resolveOrganization(org);
+        memberService.transferOwnership(userId, orgId, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/mockify/backend/dto/request/member/ChangeMemberRoleRequest.java
+++ b/src/main/java/com/mockify/backend/dto/request/member/ChangeMemberRoleRequest.java
@@ -1,0 +1,12 @@
+package com.mockify.backend.dto.request.member;
+
+import com.mockify.backend.common.enums.MemberRole;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class ChangeMemberRoleRequest {
+    @NotNull
+    private MemberRole role;
+}

--- a/src/main/java/com/mockify/backend/dto/request/member/InviteMemberRequest.java
+++ b/src/main/java/com/mockify/backend/dto/request/member/InviteMemberRequest.java
@@ -1,0 +1,18 @@
+package com.mockify.backend.dto.request.member;
+
+import com.mockify.backend.common.enums.MemberRole;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class InviteMemberRequest {
+    @NotBlank @Email
+    private String email;
+
+    @NotNull
+    private MemberRole role;
+}

--- a/src/main/java/com/mockify/backend/dto/request/member/TransferOwnershipRequest.java
+++ b/src/main/java/com/mockify/backend/dto/request/member/TransferOwnershipRequest.java
@@ -1,0 +1,12 @@
+package com.mockify.backend.dto.request.member;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import java.util.UUID;
+
+@Getter @Setter
+public class TransferOwnershipRequest {
+    @NotNull
+    private UUID newOwnerId;
+}

--- a/src/main/java/com/mockify/backend/dto/response/member/InvitationResponse.java
+++ b/src/main/java/com/mockify/backend/dto/response/member/InvitationResponse.java
@@ -1,0 +1,16 @@
+package com.mockify.backend.dto.response.member;
+
+import com.mockify.backend.common.enums.MemberRole;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class InvitationResponse {
+    private UUID id;
+    private String email;
+    private MemberRole role;
+    private String invitedByName;
+    private LocalDateTime expiresAt;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/mockify/backend/dto/response/member/MemberResponse.java
+++ b/src/main/java/com/mockify/backend/dto/response/member/MemberResponse.java
@@ -1,0 +1,21 @@
+package com.mockify.backend.dto.response.member;
+
+import com.mockify.backend.common.enums.MemberRole;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberResponse {
+    private UUID id;
+    private UUID userId;
+    private String name;
+    private String email;
+    private String avatarUrl;
+    private MemberRole role;
+    private LocalDateTime joinedAt;
+}

--- a/src/main/java/com/mockify/backend/dto/response/organization/OrganizationDetailResponse.java
+++ b/src/main/java/com/mockify/backend/dto/response/organization/OrganizationDetailResponse.java
@@ -1,5 +1,6 @@
 package com.mockify.backend.dto.response.organization;
 
+import com.mockify.backend.common.enums.MemberRole;
 import com.mockify.backend.dto.response.auth.UserResponse;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ public class OrganizationDetailResponse {
     private UserResponse owner;
     private LocalDateTime createdAt;
     private List<ProjectSummary> projects;
+    private MemberRole userRole;
 
     @Data
     public static class ProjectSummary {

--- a/src/main/java/com/mockify/backend/dto/response/organization/OrganizationResponse.java
+++ b/src/main/java/com/mockify/backend/dto/response/organization/OrganizationResponse.java
@@ -1,5 +1,6 @@
 package com.mockify.backend.dto.response.organization;
 
+import com.mockify.backend.common.enums.MemberRole;
 import lombok.*;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -18,4 +19,5 @@ public class OrganizationResponse {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private int projectCount;
+    private MemberRole userRole;
 }

--- a/src/main/java/com/mockify/backend/mapper/OrganizationMapper.java
+++ b/src/main/java/com/mockify/backend/mapper/OrganizationMapper.java
@@ -17,6 +17,7 @@ public interface OrganizationMapper {
     @Mapping(target = "ownerId", source = "owner.id")
     @Mapping(target = "ownerName", source = "owner.name")
     @Mapping(target = "projectCount", expression = "java(organization.getProjects().size())")
+    @Mapping(target = "userRole", ignore = true)
     OrganizationResponse toResponse(Organization organization);
 
     List<OrganizationResponse> toResponseList(List<Organization> organizations);

--- a/src/main/java/com/mockify/backend/mapper/OrganizationMapper.java
+++ b/src/main/java/com/mockify/backend/mapper/OrganizationMapper.java
@@ -25,6 +25,7 @@ public interface OrganizationMapper {
     // Detailed response with owner & projects
     @Mapping(target = "owner", source = "owner")
     @Mapping(target = "projects", source = "projects")
+    @Mapping(target = "userRole", ignore = true)
     OrganizationDetailResponse toDetailResponse(Organization organization);
 
     // Project summary for nested response

--- a/src/main/java/com/mockify/backend/model/Organization.java
+++ b/src/main/java/com/mockify/backend/model/Organization.java
@@ -42,6 +42,10 @@ public class Organization {
     @OneToMany(mappedBy = "organization", cascade = CascadeType.ALL)
     private Set<Project> projects = new HashSet<>();
 
+    @JsonIgnore
+    @OneToMany(mappedBy = "organization", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<OrganizationMember> members = new HashSet<>();
+
     @PrePersist
     protected void onCreate() {
         if (createdAt == null) {

--- a/src/main/java/com/mockify/backend/model/OrganizationInvitation.java
+++ b/src/main/java/com/mockify/backend/model/OrganizationInvitation.java
@@ -1,0 +1,62 @@
+package com.mockify.backend.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.mockify.backend.common.enums.MemberRole;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "organization_invitations")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class OrganizationInvitation {
+
+    @Id @GeneratedValue
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id", nullable = false)
+    private Organization organization;
+
+    @Column(nullable = false, length = 255)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private MemberRole role;
+
+    @Column(name = "token_hash", nullable = false, length = 255)
+    private String tokenHash;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invited_by", nullable = false)
+    private User invitedBy;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "accepted_at")
+    private LocalDateTime acceptedAt;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) createdAt = LocalDateTime.now();
+    }
+
+    public boolean isPending() {
+        return acceptedAt == null
+                && cancelledAt == null
+                && expiresAt.isAfter(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/mockify/backend/model/OrganizationMember.java
+++ b/src/main/java/com/mockify/backend/model/OrganizationMember.java
@@ -1,0 +1,53 @@
+package com.mockify.backend.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.mockify.backend.common.enums.MemberRole;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "organization_members",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"organization_id","user_id"})
+)
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class OrganizationMember {
+
+    @Id @GeneratedValue
+    @Column(updatable = false, nullable = false)
+    private UUID id;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id", nullable = false)
+    private Organization organization;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private MemberRole role;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invited_by")
+    private User invitedBy;
+
+    @Column(name = "joined_at", nullable = false)
+    private LocalDateTime joinedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) createdAt = LocalDateTime.now();
+        if (joinedAt  == null) joinedAt  = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/mockify/backend/repository/OrganizationInvitationRepository.java
+++ b/src/main/java/com/mockify/backend/repository/OrganizationInvitationRepository.java
@@ -1,0 +1,52 @@
+package com.mockify.backend.repository;
+
+import com.mockify.backend.model.OrganizationInvitation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface OrganizationInvitationRepository extends JpaRepository<OrganizationInvitation, UUID> {
+
+    @Query("""
+        SELECT i FROM OrganizationInvitation i
+        WHERE i.organization.id = :orgId
+          AND i.acceptedAt IS NULL
+          AND i.cancelledAt IS NULL
+    """)
+    List<OrganizationInvitation> findPendingInvitationsByOrganizationId(@Param("orgId") UUID orgId);
+
+    @Query("""
+        SELECT i FROM OrganizationInvitation i
+        WHERE i.organization.id = :orgId
+          AND i.email = :email
+          AND i.acceptedAt IS NULL
+          AND i.cancelledAt IS NULL
+    """)
+    Optional<OrganizationInvitation> findPendingInvitationByEmail(
+            @Param("orgId") UUID orgId,
+            @Param("email") String email
+    );
+
+    @Query("""
+        SELECT i FROM OrganizationInvitation i
+        WHERE i.tokenHash = :tokenHash
+          AND i.acceptedAt IS NULL
+          AND i.cancelledAt IS NULL
+          AND i.expiresAt > :now
+    """)
+    Optional<OrganizationInvitation> findPendingInvitationByTokenHash(
+            @Param("tokenHash") String tokenHash,
+            @Param("now") LocalDateTime now);
+
+    @Modifying
+    @Query("DELETE FROM OrganizationInvitation i WHERE i.expiresAt < :now AND i.acceptedAt IS NULL AND i.cancelledAt IS NULL")
+    int deleteExpiredInvitations(@Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/mockify/backend/repository/OrganizationMemberRepository.java
+++ b/src/main/java/com/mockify/backend/repository/OrganizationMemberRepository.java
@@ -1,0 +1,37 @@
+package com.mockify.backend.repository;
+
+import com.mockify.backend.common.enums.MemberRole;
+import com.mockify.backend.model.Organization;
+import com.mockify.backend.model.OrganizationMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface OrganizationMemberRepository extends JpaRepository<OrganizationMember, UUID> {
+
+    Optional<OrganizationMember> findByOrganizationIdAndUserId(UUID orgId, UUID userId);
+
+    List<OrganizationMember> findByOrganizationId(UUID orgId);
+
+    boolean existsByOrganizationIdAndUserId(UUID orgId, UUID userId);
+
+    @Query("SELECT m.role FROM OrganizationMember m WHERE m.organization.id = :orgId AND m.user.id = :userId")
+    Optional<MemberRole> findRoleByOrganizationIdAndUserId(@Param("orgId") UUID orgId, @Param("userId") UUID userId);
+
+    @Query("""
+        SELECT m.organization FROM OrganizationMember m
+        WHERE m.user.id = :userId
+        ORDER BY m.organization.createdAt DESC
+    """)
+    List<Organization> findOrganizationsByMemberId(@Param("userId") UUID userId);
+
+    long countByOrganizationId(UUID orgId);
+
+    void deleteByOrganizationIdAndUserId(UUID orgId, UUID userId);
+}

--- a/src/main/java/com/mockify/backend/scheduler/InvitationCleanupScheduler.java
+++ b/src/main/java/com/mockify/backend/scheduler/InvitationCleanupScheduler.java
@@ -1,0 +1,43 @@
+// src/main/java/com/mockify/backend/scheduler/InvitationCleanupScheduler.java
+package com.mockify.backend.scheduler;
+
+import com.mockify.backend.repository.OrganizationInvitationRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InvitationCleanupScheduler {
+
+    private final OrganizationInvitationRepository invitationRepo;
+
+    @Value("${cleanup.invitations.enabled:true}")
+    private boolean enabled;
+
+    @Scheduled(cron = "${cleanup.invitations.cron}")
+    @Transactional
+    public void cleanExpiredInvitations() {
+        if (!enabled) return;
+        try {
+            int deleted = invitationRepo.deleteExpiredInvitations(LocalDateTime.now());
+            if (deleted > 0) {
+                log.info("[Cleanup] Deleted {} expired invitations", deleted);
+            }
+        } catch (Exception ex) {
+            log.error("[Cleanup] Invitation cleanup failed", ex);
+        }
+    }
+
+    @PostConstruct
+    public void init() {
+        log.info("InvitationCleanupScheduler initialized");
+    }
+}

--- a/src/main/java/com/mockify/backend/security/MockifyPermissionEvaluator.java
+++ b/src/main/java/com/mockify/backend/security/MockifyPermissionEvaluator.java
@@ -1,15 +1,13 @@
 package com.mockify.backend.security;
 
+import com.mockify.backend.common.enums.MemberRole;
 import com.mockify.backend.model.ApiKeyPermission.ApiPermission;
 import com.mockify.backend.model.ApiKeyPermission.ApiResourceType;
 import com.mockify.backend.model.MockRecord;
 import com.mockify.backend.model.MockSchema;
 import com.mockify.backend.model.Organization;
 import com.mockify.backend.model.Project;
-import com.mockify.backend.repository.MockRecordRepository;
-import com.mockify.backend.repository.MockSchemaRepository;
-import com.mockify.backend.repository.OrganizationRepository;
-import com.mockify.backend.repository.ProjectRepository;
+import com.mockify.backend.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.PermissionEvaluator;
@@ -18,6 +16,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import java.io.Serializable;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -89,6 +88,7 @@ public class MockifyPermissionEvaluator implements PermissionEvaluator {
     private final ProjectRepository projectRepository;
     private final MockSchemaRepository mockSchemaRepository;
     private final MockRecordRepository mockRecordRepository;
+    private final OrganizationMemberRepository memberRepository;
 
     // -------------------------------------------------------------------------
     // PermissionEvaluator contract
@@ -181,7 +181,7 @@ public class MockifyPermissionEvaluator implements PermissionEvaluator {
         if (auth instanceof ApiKeyAuthenticationToken token) {
             return evaluateApiKey(token, ctx, resourceType, requiredPermission, targetId, resourceTypeOverride != null);
         } else {
-            return evaluateJwt(auth, ctx);
+            return evaluateJwt(auth, ctx, requiredPermission, resourceType);
         }
     }
 
@@ -189,17 +189,36 @@ public class MockifyPermissionEvaluator implements PermissionEvaluator {
     // JWT path — org ownership is sufficient for all operations
     // -------------------------------------------------------------------------
 
-    private boolean evaluateJwt(Authentication auth, ResourceContext ctx) {
+    private boolean evaluateJwt(Authentication auth, ResourceContext ctx,
+                                ApiPermission requiredPermission, ApiResourceType resourceType) {
         UUID callerId = resolveJwtUserId(auth);
-        if (callerId == null) {
+        if (callerId == null) return false;
+
+        Optional<MemberRole> roleOpt = memberRepository
+                .findRoleByOrganizationIdAndUserId(ctx.organization().getId(), callerId);
+
+        if (roleOpt.isEmpty()) {
+            log.debug("JWT access denied: user {} is not a member of org {}",
+                    callerId, ctx.organization().getId());
             return false;
         }
 
-        boolean owns = ctx.organization().getOwner().getId().equals(callerId);
-        if (!owns) {
-            log.debug("JWT access denied: user {} does not own org {}", callerId, ctx.organization().getId());
+        MemberRole role = roleOpt.get();
+
+        boolean granted = switch (requiredPermission) {
+            case READ  -> true;                                          // any member can read
+            case WRITE -> role.atLeast(MemberRole.DEVELOPER);
+            case DELETE -> resourceType == ApiResourceType.ORGANIZATION
+                    ? role == MemberRole.OWNER
+                    : role.atLeast(MemberRole.ADMIN);
+            case ADMIN -> role.atLeast(MemberRole.ADMIN);
+        };
+
+        if (!granted) {
+            log.debug("JWT access denied: user {} role {} insufficient for {} on {}",
+                    callerId, role, requiredPermission, resourceType);
         }
-        return owns;
+        return granted;
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/com/mockify/backend/service/MailService.java
+++ b/src/main/java/com/mockify/backend/service/MailService.java
@@ -7,4 +7,7 @@ public interface MailService {
 
     // Send email verification link to email
     void sendEmailVerificationMail(String to, String verifyLink);
+
+    void sendInvitationEmail(String to, String orgName, String inviterName,
+                             String role, String acceptLink);
 }

--- a/src/main/java/com/mockify/backend/service/OrganizationMemberService.java
+++ b/src/main/java/com/mockify/backend/service/OrganizationMemberService.java
@@ -1,0 +1,152 @@
+package com.mockify.backend.service;
+
+import com.mockify.backend.dto.request.member.*;
+import com.mockify.backend.dto.response.member.*;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Service contract for managing organization membership and invitations.
+ *
+ * <p>This service encapsulates:
+ * - Member lifecycle (add, remove, role changes, leave)
+ * - Invitation lifecycle (invite, accept, cancel, list)
+ * - Ownership management (transfer)
+ *
+ * <p>All methods are expected to enforce:
+ * - Role-based authorization using {@link com.mockify.backend.common.enums.MemberRole}
+ * - Organization scoping (actor must belong to the org where required)
+ * - Invariants such as:
+ *   - Single OWNER per organization
+ *   - No duplicate membership
+ *   - Invitation validity (not expired / already used)
+ *
+ * <p>Implementations should be transactional where mutations occur.
+ */
+public interface OrganizationMemberService {
+
+    /**
+     * Invite a user (by email) to join an organization with a specific role.
+     *
+     * <p>Rules:
+     * - Actor must have permission to invite (ADMIN+ typically)
+     * - Actor cannot invite someone with a role >= their own
+     * - Existing pending invitations for the same email may be replaced
+     * - If the email already belongs to a member, this should fail
+     *
+     * @param actorId ID of the user performing the action
+     * @param orgId organization ID
+     * @param request invite payload (email + role)
+     */
+    void inviteMember(UUID actorId, UUID orgId, InviteMemberRequest request);
+
+    /**
+     * Accept an invitation using a raw token.
+     *
+     * <p>Rules:
+     * - Token must be valid, not expired, and not already used
+     * - Email of accepting user must match invitation email
+     * - Operation should be idempotent (accepting twice should not fail)
+     *
+     * @param rawToken invitation token (unhashed)
+     * @param acceptingUserId ID of the user accepting the invitation
+     */
+    void acceptInvitation(String rawToken, UUID acceptingUserId);
+
+    /**
+     * List all members of an organization.
+     *
+     * <p>Rules:
+     * - Requester must be a member of the organization
+     *
+     * @param requesterId ID of requesting user
+     * @param orgId organization ID
+     * @return list of members with basic profile + role
+     */
+    List<MemberResponse> listMembers(UUID requesterId, UUID orgId);
+
+    /**
+     * List all pending invitations for an organization.
+     *
+     * <p>Rules:
+     * - Typically restricted to ADMIN+ roles
+     * - Only active (not accepted/cancelled/expired) invitations should be returned
+     *
+     * @param requesterId ID of requesting user
+     * @param orgId organization ID
+     * @return list of pending invitations
+     */
+    List<InvitationResponse> listPendingInvitations(UUID requesterId, UUID orgId);
+
+    /**
+     * Change the role of an existing member.
+     *
+     * <p>Rules:
+     * - Actor must be allowed to manage the target member
+     * - Actor cannot assign a role >= their own
+     * - OWNER role changes are restricted (cannot be arbitrarily reassigned)
+     *
+     * @param actorId ID of user performing the action
+     * @param orgId organization ID
+     * @param targetUserId member whose role is being changed
+     * @param request new role
+     * @return updated member representation
+     */
+    MemberResponse changeMemberRole(UUID actorId, UUID orgId, UUID targetUserId, ChangeMemberRoleRequest request);
+
+    /**
+     * Remove a member from the organization.
+     *
+     * <p>Rules:
+     * - Actor cannot remove themselves via this method (use leaveOrganization)
+     * - Actor must be allowed to manage the target member
+     * - OWNER cannot be removed
+     *
+     * @param actorId ID of user performing the action
+     * @param orgId organization ID
+     * @param targetUserId member to remove
+     */
+    void removeMember(UUID actorId, UUID orgId, UUID targetUserId);
+
+    /**
+     * Cancel an existing invitation.
+     *
+     * <p>Rules:
+     * - Typically restricted to ADMIN+ roles
+     * - Invitation must belong to the specified organization
+     *
+     * @param actorId ID of user performing the action
+     * @param orgId organization ID
+     * @param invitationId invitation to cancel
+     */
+    void cancelInvitation(UUID actorId, UUID orgId, UUID invitationId);
+
+    /**
+     * Allow a user to leave an organization voluntarily.
+     *
+     * <p>Rules:
+     * - OWNER cannot leave without transferring ownership first
+     *
+     * @param userId ID of user leaving
+     * @param orgId organization ID
+     */
+    void leaveOrganization(UUID userId, UUID orgId);
+
+    /**
+     * Transfer ownership of an organization to another existing member.
+     *
+     * <p>Rules:
+     * - Only current OWNER can perform this action
+     * - Target user must already be a member
+     * - After transfer:
+     *   - New user becomes OWNER
+     *   - Previous owner is downgraded (typically to ADMIN)
+     * - Must maintain "single OWNER" invariant
+     *
+     * @param currentOwnerId ID of current owner
+     * @param orgId organization ID
+     * @param request contains new owner user ID
+     */
+    void transferOwnership(UUID currentOwnerId, UUID orgId, TransferOwnershipRequest request);
+}

--- a/src/main/java/com/mockify/backend/service/impl/MailServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MailServiceImpl.java
@@ -85,8 +85,22 @@ public class MailServiceImpl implements MailService {
         }
     }
 
+    private static String escapeHtml(String input) {
+        if (input == null) return "";
+        return input
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#x27;");
+    }
+
     private String buildInviteHtml(String orgName, String inviterName,
                                    String role, String acceptLink) {
+        String safeOrg     = escapeHtml(orgName);
+        String safeInviter = escapeHtml(inviterName);
+        String safeRole    = escapeHtml(role);
+
         return """
         <div style="background:#f6f8fa;padding:40px 0;font-family:-apple-system,sans-serif;">
           <table align="center" width="100%%" cellpadding="0" cellspacing="0"
@@ -116,7 +130,7 @@ public class MailServiceImpl implements MailService {
             </td></tr>
           </table>
         </div>
-    """.formatted(orgName, inviterName, orgName, role, acceptLink);
+    """.formatted(safeOrg, safeInviter, safeOrg, safeRole, acceptLink);
     }
 
     private String buildVerificationHtml(String verificationLink) {

--- a/src/main/java/com/mockify/backend/service/impl/MailServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MailServiceImpl.java
@@ -71,8 +71,52 @@ public class MailServiceImpl implements MailService {
     @Override
     public void sendInvitationEmail(String to, String orgName, String inviterName,
                                     String role, String acceptLink) {
-        // TODO: implement the logic
-        log.info("STUB — invite email to {} for org {} role {}", to, orgName, role);
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setFrom("Mockify <mockify.noreply@gmail.com>");
+            helper.setTo(to);
+            helper.setSubject(inviterName + " invited you to " + orgName + " on Mockify");
+            helper.setText(buildInviteHtml(orgName, inviterName, role, acceptLink), true);
+            mailSender.send(message);
+            log.info("Invitation email sent to {}", to);
+        } catch (Exception ex) {
+            log.error("Failed to send invitation email to {}", to, ex);
+        }
+    }
+
+    private String buildInviteHtml(String orgName, String inviterName,
+                                   String role, String acceptLink) {
+        return """
+        <div style="background:#f6f8fa;padding:40px 0;font-family:-apple-system,sans-serif;">
+          <table align="center" width="100%%" cellpadding="0" cellspacing="0"
+                 style="max-width:480px;background:#fff;border-radius:6px;border:1px solid #d0d7de;">
+            <tr><td style="padding:32px;">
+              <h2 style="text-align:center;margin-top:0;color:#24292f;font-size:20px;">
+                You're invited to join %s
+              </h2>
+              <p style="color:#57606a;font-size:14px;line-height:1.5;">
+                <strong>%s</strong> has invited you to collaborate on
+                <strong>%s</strong> as a <strong>%s</strong>.
+              </p>
+              <div style="margin:24px 0;text-align:center;">
+                <a href="%s"
+                   style="background:#2da44e;color:#fff;padding:10px 20px;
+                          text-decoration:none;border-radius:6px;font-size:14px;
+                          display:inline-block;">
+                  Accept invitation
+                </a>
+              </div>
+              <p style="color:#57606a;font-size:13px;">
+                This invitation expires in <strong>48 hours</strong>.
+              </p>
+              <p style="font-size:13px;color:#57606a;margin-top:24px;">
+                Thanks,<br><strong>The Mockify Team</strong>
+              </p>
+            </td></tr>
+          </table>
+        </div>
+    """.formatted(orgName, inviterName, orgName, role, acceptLink);
     }
 
     private String buildVerificationHtml(String verificationLink) {

--- a/src/main/java/com/mockify/backend/service/impl/MailServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MailServiceImpl.java
@@ -68,6 +68,13 @@ public class MailServiceImpl implements MailService {
         }
     }
 
+    @Override
+    public void sendInvitationEmail(String to, String orgName, String inviterName,
+                                    String role, String acceptLink) {
+        // TODO: implement the logic
+        log.info("STUB — invite email to {} for org {} role {}", to, orgName, role);
+    }
+
     private String buildVerificationHtml(String verificationLink) {
         return """
         <div style="background-color:#f6f8fa; padding:40px 0; 

--- a/src/main/java/com/mockify/backend/service/impl/OrganizationMemberServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/OrganizationMemberServiceImpl.java
@@ -169,9 +169,14 @@ public class OrganizationMemberServiceImpl implements OrganizationMemberService 
     @Override
     @Transactional
     public MemberResponse changeMemberRole(UUID actorId, UUID orgId,
-                                           UUID targetUserId, ChangeMemberRoleRequest request) {
-        MemberRole actorRole = resolveRole(actorId, orgId);
+                                           UUID targetUserId,
+                                           ChangeMemberRoleRequest request) {
+        // Guard: actors cannot modify their own role
+        if (actorId.equals(targetUserId)) {
+            throw new BadRequestException("You cannot change your own role");
+        }
 
+        MemberRole actorRole = resolveRole(actorId, orgId);
         OrganizationMember target = memberRepo
                 .findByOrganizationIdAndUserId(orgId, targetUserId)
                 .orElseThrow(() -> new ResourceNotFoundException("Member not found"));
@@ -180,7 +185,8 @@ public class OrganizationMemberServiceImpl implements OrganizationMemberService 
             throw new ForbiddenException("You cannot change the role of this member");
         }
         if (!actorRole.canInviteAs(request.getRole())) {
-            throw new ForbiddenException("You cannot assign a role equal to or above your own");
+            throw new ForbiddenException(
+                    "You cannot assign a role equal to or above your own");
         }
 
         target.setRole(request.getRole());
@@ -254,8 +260,13 @@ public class OrganizationMemberServiceImpl implements OrganizationMemberService 
     @Transactional
     public void transferOwnership(UUID currentOwnerId, UUID orgId,
                                   TransferOwnershipRequest request) {
-        MemberRole actorRole = resolveRole(currentOwnerId, orgId);
+        // reject self-transfer
+        if (request.getNewOwnerId().equals(currentOwnerId)) {
+            throw new BadRequestException(
+                    "You are already the owner of this organization");
+        }
 
+        MemberRole actorRole = resolveRole(currentOwnerId, orgId);
         if (actorRole != MemberRole.OWNER) {
             throw new ForbiddenException("Only the current OWNER can transfer ownership");
         }
@@ -267,7 +278,9 @@ public class OrganizationMemberServiceImpl implements OrganizationMemberService 
 
         OrganizationMember currentOwner = memberRepo
                 .findByOrganizationIdAndUserId(orgId, currentOwnerId)
-                .orElseThrow();
+                .orElseThrow(() -> new IllegalStateException(
+                        "OWNER member row missing for user " + currentOwnerId
+                                + " in org " + orgId + " — data integrity violation"));
 
         // saveAndFlush the demotion first
         currentOwner.setRole(MemberRole.ADMIN);

--- a/src/main/java/com/mockify/backend/service/impl/OrganizationMemberServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/OrganizationMemberServiceImpl.java
@@ -1,0 +1,328 @@
+package com.mockify.backend.service.impl;
+
+import com.mockify.backend.common.enums.MemberRole;
+import com.mockify.backend.dto.request.member.*;
+import com.mockify.backend.dto.response.member.*;
+import com.mockify.backend.exception.*;
+import com.mockify.backend.model.*;
+import com.mockify.backend.repository.*;
+import com.mockify.backend.service.MailService;
+import com.mockify.backend.service.OrganizationMemberService;
+import com.mockify.backend.util.InvitationTokenUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrganizationMemberServiceImpl implements OrganizationMemberService {
+
+    private final OrganizationMemberRepository memberRepo;
+    private final OrganizationInvitationRepository invitationRepo;
+    private final OrganizationRepository orgRepo;
+    private final UserRepository userRepo;
+    private final MailService mailService;
+
+    @Value("${app.frontend.url}")
+    private String frontendUrl;
+
+    @Override
+    @Transactional
+    public void inviteMember(UUID actorId, UUID orgId, InviteMemberRequest request) {
+        // normalize email at service boundary before any lookup or storage
+        String email = request.getEmail().trim().toLowerCase();
+
+        Organization org = orgRepo.findById(orgId)
+                .orElseThrow(() -> new ResourceNotFoundException("Organization not found"));
+
+        MemberRole actorRole = resolveRole(actorId, orgId);
+
+        if (!actorRole.canInviteAs(request.getRole())) {
+            throw new ForbiddenException(
+                    "You need ADMIN or higher role to invite members, " +
+                            "and cannot invite someone to a role equal to or above your own.");
+        }
+
+        // If target email already has an account and is already a member, reject
+        userRepo.findByEmail(email).ifPresent(user -> {
+            if (memberRepo.existsByOrganizationIdAndUserId(orgId, user.getId())) {
+                throw new DuplicateResourceException("User is already a member of this organization");
+            }
+        });
+
+        // Cancel any existing pending invitation for same email + org
+        invitationRepo
+                .findPendingInvitationByEmail(orgId, email)
+                .ifPresent(existing -> {
+                    existing.setCancelledAt(LocalDateTime.now());
+                    invitationRepo.save(existing);
+                });
+
+        String rawToken   = UUID.randomUUID().toString();
+        String tokenHash  = InvitationTokenUtil.hash(rawToken);
+
+        User inviter = userRepo.findById(actorId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        OrganizationInvitation invitation = OrganizationInvitation.builder()
+                .organization(org)
+                .email(email)
+                .role(request.getRole())
+                .tokenHash(tokenHash)
+                .invitedBy(inviter)
+                .expiresAt(LocalDateTime.now().plusHours(48))
+                .build();
+
+        try {
+            invitationRepo.saveAndFlush(invitation);
+        } catch (DataIntegrityViolationException ex) {
+            throw new DuplicateResourceException(
+                    "An active invitation already exists for this email address");
+        }
+
+        String acceptLink = frontendUrl + "/invitations/accept?token=" + rawToken;
+        mailService.sendInvitationEmail(
+                email,
+                org.getName(),
+                inviter.getName(),
+                request.getRole().name(),
+                acceptLink);
+
+        log.info("Invitation sent to {} for org {} with role {}", email, orgId, request.getRole());
+    }
+
+    @Override
+    @Transactional
+    public void acceptInvitation(String rawToken, UUID acceptingUserId) {
+        OrganizationInvitation invitation = invitationRepo
+                .findPendingInvitationByTokenHash(InvitationTokenUtil.hash(rawToken), LocalDateTime.now())
+                .orElseThrow(() -> new UnauthorizedException("Invalid or expired invitation"));
+
+        User user = userRepo.findById(acceptingUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        if (!user.getEmail().trim().toLowerCase()
+                .equals(invitation.getEmail().trim().toLowerCase())) {
+            throw new ForbiddenException(
+                    "This invitation was sent to a different email address");
+        }
+
+        // Idempotent: already a member → mark accepted and return cleanly
+        if (memberRepo.existsByOrganizationIdAndUserId(
+                invitation.getOrganization().getId(), acceptingUserId)) {
+            invitation.setAcceptedAt(LocalDateTime.now());
+            invitationRepo.save(invitation);
+            return;
+        }
+
+        OrganizationMember member = OrganizationMember.builder()
+                .organization(invitation.getOrganization())
+                .user(user)
+                .role(invitation.getRole())
+                .invitedBy(invitation.getInvitedBy())
+                .joinedAt(LocalDateTime.now())
+                .build();
+
+        memberRepo.save(member);
+        invitation.setAcceptedAt(LocalDateTime.now());
+        invitationRepo.save(invitation);
+
+        log.info("User {} accepted invitation to org {}",
+                acceptingUserId, invitation.getOrganization().getId());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MemberResponse> listMembers(UUID requesterId, UUID orgId) {
+        requireMembership(requesterId, orgId);
+
+        return memberRepo.findByOrganizationId(orgId).stream()
+                .map(this::toMemberResponse)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<InvitationResponse> listPendingInvitations(UUID requesterId, UUID orgId) {
+        MemberRole role = resolveRole(requesterId, orgId);
+
+        if (!role.atLeast(MemberRole.ADMIN)) {
+            throw new ForbiddenException("Only ADMIN or above can view pending invitations");
+        }
+
+        return invitationRepo
+                .findPendingInvitationsByOrganizationId(orgId)
+                .stream()
+                .filter(OrganizationInvitation::isPending)
+                .map(this::toInvitationResponse)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public MemberResponse changeMemberRole(UUID actorId, UUID orgId,
+                                           UUID targetUserId, ChangeMemberRoleRequest request) {
+        MemberRole actorRole = resolveRole(actorId, orgId);
+
+        OrganizationMember target = memberRepo
+                .findByOrganizationIdAndUserId(orgId, targetUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Member not found"));
+
+        if (!actorRole.canManage(target.getRole())) {
+            throw new ForbiddenException("You cannot change the role of this member");
+        }
+        if (!actorRole.canInviteAs(request.getRole())) {
+            throw new ForbiddenException("You cannot assign a role equal to or above your own");
+        }
+
+        target.setRole(request.getRole());
+        memberRepo.save(target);
+
+        log.info("Actor {} changed role of user {} in org {} to {}",
+                actorId, targetUserId, orgId, request.getRole());
+        return toMemberResponse(target);
+    }
+
+    @Override
+    @Transactional
+    public void removeMember(UUID actorId, UUID orgId, UUID targetUserId) {
+        MemberRole actorRole = resolveRole(actorId, orgId);
+
+        OrganizationMember target = memberRepo
+                .findByOrganizationIdAndUserId(orgId, targetUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Member not found"));
+
+        if (actorId.equals(targetUserId)) {
+            throw new BadRequestException("Use the leave endpoint to remove yourself");
+        }
+        if (!actorRole.canManage(target.getRole())) {
+            throw new ForbiddenException("You cannot remove this member");
+        }
+
+        memberRepo.delete(target);
+        log.warn("User {} removed from org {} by actor {}", targetUserId, orgId, actorId);
+    }
+
+    @Override
+    @Transactional
+    public void cancelInvitation(UUID actorId, UUID orgId, UUID invitationId) {
+        MemberRole actorRole = resolveRole(actorId, orgId);
+
+        if (!actorRole.atLeast(MemberRole.ADMIN)) {
+            throw new ForbiddenException("Only ADMIN or above can cancel invitations");
+        }
+
+        OrganizationInvitation invitation = invitationRepo.findById(invitationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Invitation not found"));
+
+        if (!invitation.getOrganization().getId().equals(orgId)) {
+            throw new ResourceNotFoundException("Invitation not found");
+        }
+
+        invitation.setCancelledAt(LocalDateTime.now());
+        invitationRepo.save(invitation);
+
+        log.info("Invitation {} cancelled by actor {} in org {}", invitationId, actorId, orgId);
+    }
+
+    @Override
+    @Transactional
+    public void leaveOrganization(UUID userId, UUID orgId) {
+        OrganizationMember member = memberRepo
+                .findByOrganizationIdAndUserId(orgId, userId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "You are not a member of this organization"));
+
+        if (member.getRole() == MemberRole.OWNER) {
+            throw new BadRequestException(
+                    "Owners cannot leave. Transfer ownership first, then leave.");
+        }
+
+        memberRepo.delete(member);
+        log.info("User {} left org {}", userId, orgId);
+    }
+
+    @Override
+    @Transactional
+    public void transferOwnership(UUID currentOwnerId, UUID orgId,
+                                  TransferOwnershipRequest request) {
+        MemberRole actorRole = resolveRole(currentOwnerId, orgId);
+
+        if (actorRole != MemberRole.OWNER) {
+            throw new ForbiddenException("Only the current OWNER can transfer ownership");
+        }
+
+        OrganizationMember newOwnerMember = memberRepo
+                .findByOrganizationIdAndUserId(orgId, request.getNewOwnerId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Target user is not a member of this organization"));
+
+        OrganizationMember currentOwner = memberRepo
+                .findByOrganizationIdAndUserId(orgId, currentOwnerId)
+                .orElseThrow();
+
+        // saveAndFlush the demotion first
+        currentOwner.setRole(MemberRole.ADMIN);
+        memberRepo.saveAndFlush(currentOwner);
+
+        // Safe to promote now — previous OWNER row is already committed as ADMIN
+        newOwnerMember.setRole(MemberRole.OWNER);
+        memberRepo.save(newOwnerMember);
+
+        // Keep legacy owner_id column in sync for backward compatibility
+        Organization org = orgRepo.findById(orgId)
+                .orElseThrow(() -> new ResourceNotFoundException("Organization not found"));
+        org.setOwner(newOwnerMember.getUser());
+        orgRepo.save(org);
+
+        log.warn("Ownership of org {} transferred from {} to {}",
+                orgId, currentOwnerId, request.getNewOwnerId());
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private MemberRole resolveRole(UUID userId, UUID orgId) {
+        return memberRepo.findRoleByOrganizationIdAndUserId(orgId, userId)
+                .orElseThrow(() -> new ForbiddenException(
+                        "You are not a member of this organization"));
+    }
+
+    private void requireMembership(UUID userId, UUID orgId) {
+        if (!memberRepo.existsByOrganizationIdAndUserId(orgId, userId)) {
+            throw new ForbiddenException("You are not a member of this organization");
+        }
+    }
+
+    private MemberResponse toMemberResponse(OrganizationMember m) {
+        return MemberResponse.builder()
+                .id(m.getId())
+                .userId(m.getUser().getId())
+                .name(m.getUser().getName())
+                .email(m.getUser().getEmail())
+                .avatarUrl(m.getUser().getAvatarUrl())
+                .role(m.getRole())
+                .joinedAt(m.getJoinedAt())
+                .build();
+    }
+
+    private InvitationResponse toInvitationResponse(OrganizationInvitation i) {
+        return InvitationResponse.builder()
+                .id(i.getId())
+                .email(i.getEmail())
+                .role(i.getRole())
+                .invitedByName(i.getInvitedBy().getName())
+                .expiresAt(i.getExpiresAt())
+                .createdAt(i.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/mockify/backend/service/impl/OrganizationServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/OrganizationServiceImpl.java
@@ -11,6 +11,7 @@ import com.mockify.backend.exception.DuplicateResourceException;
 import com.mockify.backend.exception.ResourceNotFoundException;
 import com.mockify.backend.mapper.OrganizationMapper;
 import com.mockify.backend.model.Organization;
+import com.mockify.backend.model.OrganizationMember;
 import com.mockify.backend.model.User;
 import com.mockify.backend.repository.OrganizationMemberRepository;
 import com.mockify.backend.repository.OrganizationRepository;
@@ -72,6 +73,15 @@ public class OrganizationServiceImpl implements OrganizationService {
 
         Organization saved = organizationRepository.save(organization);
         endpointService.createEndpoint(saved);
+
+        OrganizationMember ownerMember = OrganizationMember.builder()
+                .organization(saved)
+                .user(user)
+                .role(MemberRole.OWNER)
+                .joinedAt(saved.getCreatedAt())
+                .build();
+        memberRepository.save(ownerMember);
+
 
         log.info("Organization '{}' created by user {}", saved.getName(), userId);
         return organizationMapper.toResponse(saved);

--- a/src/main/java/com/mockify/backend/service/impl/OrganizationServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/OrganizationServiceImpl.java
@@ -1,5 +1,6 @@
 package com.mockify.backend.service.impl;
 
+import com.mockify.backend.common.enums.MemberRole;
 import com.mockify.backend.common.validation.PageableValidator;
 import com.mockify.backend.dto.request.organization.CreateOrganizationRequest;
 import com.mockify.backend.dto.request.organization.UpdateOrganizationRequest;
@@ -11,6 +12,7 @@ import com.mockify.backend.exception.ResourceNotFoundException;
 import com.mockify.backend.mapper.OrganizationMapper;
 import com.mockify.backend.model.Organization;
 import com.mockify.backend.model.User;
+import com.mockify.backend.repository.OrganizationMemberRepository;
 import com.mockify.backend.repository.OrganizationRepository;
 import com.mockify.backend.repository.UserRepository;
 import com.mockify.backend.service.EndpointService;
@@ -37,6 +39,7 @@ public class OrganizationServiceImpl implements OrganizationService {
     private final OrganizationMapper organizationMapper;
     private final SlugService slugService;
     private final EndpointService endpointService;
+    private final OrganizationMemberRepository memberRepository;
 
     // Create new organization under current user
     // The JWT-only guard at the controller (requireJwtAuthentication) is sufficient.
@@ -95,7 +98,15 @@ public class OrganizationServiceImpl implements OrganizationService {
 
         Organization organization = organizationRepository.findByIdWithOwnerAndProjects(orgId)
                 .orElseThrow(() -> new ResourceNotFoundException("Organization not found with id: " + orgId));
-        return organizationMapper.toDetailResponse(organization);
+
+        OrganizationDetailResponse response = organizationMapper.toDetailResponse(organization);
+
+        MemberRole userRole = memberRepository
+                .findRoleByOrganizationIdAndUserId(orgId, userId)
+                .orElse(MemberRole.VIEWER);
+        response.setUserRole(userRole);
+
+        return response;
     }
 
     // Returns only the caller's own orgs — no cross-org risk, no guard needed.

--- a/src/main/java/com/mockify/backend/util/InvitationTokenUtil.java
+++ b/src/main/java/com/mockify/backend/util/InvitationTokenUtil.java
@@ -1,0 +1,24 @@
+package com.mockify.backend.util;
+
+import java.security.MessageDigest;
+import java.util.HexFormat;
+
+public final class InvitationTokenUtil {
+
+    private InvitationTokenUtil() {}
+
+    /**
+     * Returns the SHA-256 hex digest of rawToken.
+     * Deterministic — same input always produces the same 64-char hex string.
+     * Use this for both storing and looking up invitation tokens.
+     */
+    public static String hash(String rawToken) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(rawToken.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -7,6 +7,11 @@ spring:
     username: mockify_user
     password: mockify_password
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   jpa:
     show-sql: true
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,6 +95,10 @@ cleanup:
     enabled: true
     cron: "0 */10 * * * *" # every 10 minutes
 
+  invitations:
+    enabled: true
+    cron: "0 0 * * * *"   # top of every hour
+
 # Actuator configuration
 management:
   endpoints:

--- a/src/main/resources/db/migration/V12__organization_members.sql
+++ b/src/main/resources/db/migration/V12__organization_members.sql
@@ -1,0 +1,64 @@
+CREATE TABLE organization_members (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role            VARCHAR(20) NOT NULL,
+    invited_by      UUID REFERENCES users(id) ON DELETE SET NULL,
+    joined_at       TIMESTAMP NOT NULL DEFAULT NOW(),
+    created_at      TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT org_members_unique UNIQUE (organization_id, user_id),
+    -- Using VARCHAR + CHECK instead of ENUM for operational flexibility
+    CONSTRAINT org_members_role_check CHECK (role IN ('OWNER','ADMIN','DEVELOPER','VIEWER'))
+);
+
+-- Indexes
+CREATE INDEX idx_org_members_org_id ON organization_members(organization_id);
+CREATE INDEX idx_org_members_user_id ON organization_members(user_id);
+
+-- Enforce single owner
+CREATE UNIQUE INDEX one_owner_per_org
+ON organization_members (organization_id)
+WHERE role = 'OWNER';
+
+CREATE TABLE organization_invitations (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    email           VARCHAR(255) NOT NULL,
+    role            VARCHAR(20) NOT NULL DEFAULT 'DEVELOPER',
+    token_hash      VARCHAR(255) NOT NULL,
+    invited_by      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    expires_at      TIMESTAMP NOT NULL,
+    accepted_at     TIMESTAMP,
+    cancelled_at    TIMESTAMP,
+    created_at      TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT org_invitations_role_check  CHECK (role IN ('ADMIN','DEVELOPER','VIEWER')),
+    CONSTRAINT org_invitations_state_check CHECK (
+        NOT (accepted_at IS NOT NULL AND cancelled_at IS NOT NULL)
+    )
+);
+
+-- Indexes
+CREATE INDEX idx_org_invitations_org_id ON organization_invitations(organization_id);
+CREATE INDEX idx_org_invitations_email ON organization_invitations(email);
+
+-- Make token_hash globally unique
+CREATE UNIQUE INDEX idx_org_invitations_token
+ON organization_invitations(token_hash);
+
+-- Enforce unique active invitation per email per org
+-- NOTE: "active" invitations also depend on expires_at (enforced at app layer)
+CREATE UNIQUE INDEX unique_active_invite
+ON organization_invitations (organization_id, email)
+WHERE accepted_at IS NULL AND cancelled_at IS NULL;
+
+-- Index for active invite queries
+CREATE INDEX idx_active_invites
+ON organization_invitations (organization_id)
+WHERE accepted_at IS NULL AND cancelled_at IS NULL;
+
+-- Backfill existing org owners as OWNER members
+INSERT INTO organization_members (organization_id, user_id, role, joined_at)
+SELECT id, owner_id, 'OWNER', created_at
+FROM organizations
+ON CONFLICT (organization_id, user_id)
+DO UPDATE SET role = 'OWNER';

--- a/src/test/java/com/mockify/backend/common/enums/MemberRoleTest.java
+++ b/src/test/java/com/mockify/backend/common/enums/MemberRoleTest.java
@@ -1,0 +1,28 @@
+package com.mockify.backend.common.enums;
+
+import org.junit.jupiter.api.Test;
+import static com.mockify.backend.common.enums.MemberRole.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemberRoleTest {
+
+    // canManage
+    @Test void owner_can_manage_admin()      { assertTrue(OWNER.canManage(ADMIN)); }
+    @Test void owner_can_manage_developer()  { assertTrue(OWNER.canManage(DEVELOPER)); }
+    @Test void admin_can_manage_developer()  { assertTrue(ADMIN.canManage(DEVELOPER)); }
+    @Test void admin_can_manage_viewer()     { assertTrue(ADMIN.canManage(VIEWER)); }
+    @Test void admin_cannot_manage_owner()   { assertFalse(ADMIN.canManage(OWNER)); }
+    @Test void developer_cannot_manage_anyone() { assertFalse(DEVELOPER.canManage(VIEWER)); }
+    @Test void nobody_can_manage_owner()     { assertFalse(ADMIN.canManage(OWNER)); assertFalse(OWNER.canManage(OWNER)); }
+
+    // canInviteAs
+    @Test void owner_can_invite_admin()      { assertTrue(OWNER.canInviteAs(ADMIN)); }
+    @Test void admin_can_invite_developer()  { assertTrue(ADMIN.canInviteAs(DEVELOPER)); }
+    @Test void admin_cannot_invite_admin()   { assertFalse(ADMIN.canInviteAs(ADMIN)); }
+    @Test void nobody_can_invite_owner()     { assertFalse(ADMIN.canInviteAs(OWNER)); assertFalse(OWNER.canInviteAs(OWNER)); }
+
+    // atLeast
+    @Test void owner_atLeast_viewer()    { assertTrue(OWNER.atLeast(VIEWER)); }
+    @Test void viewer_not_atLeast_admin(){ assertFalse(VIEWER.atLeast(ADMIN)); }
+    @Test void admin_atLeast_admin()     { assertTrue(ADMIN.atLeast(ADMIN)); }
+}

--- a/src/test/java/com/mockify/backend/controller/OrganizationMemberControllerTest.java
+++ b/src/test/java/com/mockify/backend/controller/OrganizationMemberControllerTest.java
@@ -132,6 +132,27 @@ class OrganizationMemberControllerTest {
                 .andExpect(status().isNoContent());
     }
 
+    @Test
+    void accept_invitation_with_blank_token_returns_400() throws Exception {
+        String inviteeJwt = jwtTokenProvider
+                .generateAccessToken(dev.getId(), UserRole.USER);
+
+        mockMvc.perform(post("/api/invitations/accept")
+                        .param("token", "   ")   // blank — should fail @NotBlank
+                        .header("Authorization", "Bearer " + inviteeJwt))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void accept_invitation_rejects_api_key_callers() throws Exception {
+        mockMvc.perform(post("/api/invitations/accept")
+                        .param("token", "sometoken")
+                        .header("X-API-Key",
+                                "mk_live_fakekeyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    // HELPERS
     private User buildUser(String email) {
         User u = new User(); u.setName("Test"); u.setEmail(email);
         u.setPassword("hashed"); u.setProviderName("local"); u.setEmailVerified(true);

--- a/src/test/java/com/mockify/backend/controller/OrganizationMemberControllerTest.java
+++ b/src/test/java/com/mockify/backend/controller/OrganizationMemberControllerTest.java
@@ -1,0 +1,145 @@
+package com.mockify.backend.controller;
+
+import com.mockify.backend.common.enums.MemberRole;
+import com.mockify.backend.common.enums.UserRole;
+import com.mockify.backend.model.*;
+import com.mockify.backend.repository.*;
+import com.mockify.backend.security.JwtTokenProvider;
+import com.mockify.backend.util.InvitationTokenUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import org.mockito.Mockito;
+import com.mockify.backend.service.EndpointService;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class OrganizationMemberControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired JwtTokenProvider jwtTokenProvider;
+    @Autowired UserRepository userRepo;
+    @Autowired OrganizationRepository orgRepo;
+    @Autowired OrganizationMemberRepository memberRepo;
+    @Autowired OrganizationInvitationRepository invitationRepo;
+    @MockitoBean EndpointService endpointService;
+
+    private User owner;
+    private User dev;
+    private Organization org;
+    private String ownerJwt;
+    private String devJwt;
+
+    @BeforeEach
+    void setUp() {
+        owner = userRepo.save(buildUser("ctrl-owner@test.com"));
+        dev   = userRepo.save(buildUser("ctrl-dev@test.com"));
+        org   = orgRepo.save(buildOrg("Ctrl Org", owner));
+
+        memberRepo.save(OrganizationMember.builder()
+                .organization(org).user(owner).role(MemberRole.OWNER).joinedAt(LocalDateTime.now()).build());
+        memberRepo.save(OrganizationMember.builder()
+                .organization(org).user(dev).role(MemberRole.DEVELOPER).joinedAt(LocalDateTime.now()).build());
+
+        ownerJwt = jwtTokenProvider.generateAccessToken(owner.getId(), UserRole.USER);
+        devJwt   = jwtTokenProvider.generateAccessToken(dev.getId(), UserRole.USER);
+
+        // ADD THIS — stub slug → UUID resolution for all tests in this class
+        Mockito.when(endpointService.resolveOrganization(org.getSlug()))
+                .thenReturn(org.getId());
+    }
+
+
+    @Test
+    void listMembers_returns_200_for_member() throws Exception {
+        mockMvc.perform(get("/api/organizations/{org}/members", org.getSlug())
+                        .header("Authorization", "Bearer " + ownerJwt))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)));
+    }
+
+    @Test
+    void listMembers_returns_403_for_non_member() throws Exception {
+        User stranger = userRepo.save(buildUser("stranger@test.com"));
+        String jwt = jwtTokenProvider.generateAccessToken(stranger.getId(), UserRole.USER);
+
+        mockMvc.perform(get("/api/organizations/{org}/members", org.getSlug())
+                        .header("Authorization", "Bearer " + jwt))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void listPendingInvitations_requires_admin_role() throws Exception {
+        mockMvc.perform(get("/api/organizations/{org}/members/invitations", org.getSlug())
+                        .header("Authorization", "Bearer " + devJwt))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void listPendingInvitations_returns_200_for_owner() throws Exception {
+        mockMvc.perform(get("/api/organizations/{org}/members/invitations", org.getSlug())
+                        .header("Authorization", "Bearer " + ownerJwt))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void invite_requires_jwt_not_api_key() throws Exception {
+        // API key auth is blocked by requireJwtAuthentication()
+        mockMvc.perform(post("/api/organizations/{org}/members/invite", org.getSlug())
+                        .header("X-API-Key", "mk_live_fakekeyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"x@x.com\",\"role\":\"DEVELOPER\"}"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    void accept_invitation_adds_user_to_org() throws Exception {
+        User invitee = userRepo.save(buildUser("invitee@test.com"));
+        String raw = UUID.randomUUID().toString();
+        invitationRepo.save(OrganizationInvitation.builder()
+                .organization(org).email(invitee.getEmail()).role(MemberRole.DEVELOPER)
+                .tokenHash(InvitationTokenUtil.hash(raw)).invitedBy(owner)
+                .expiresAt(LocalDateTime.now().plusHours(48)).build());
+
+        String inviteeJwt = jwtTokenProvider.generateAccessToken(invitee.getId(), UserRole.USER);
+
+        mockMvc.perform(post("/api/invitations/accept")
+                        .param("token", raw)
+                        .header("Authorization", "Bearer " + inviteeJwt))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void remove_member_returns_204() throws Exception {
+        mockMvc.perform(delete("/api/organizations/{org}/members/{userId}", org.getSlug(), dev.getId())
+                        .header("Authorization", "Bearer " + ownerJwt))
+                .andExpect(status().isNoContent());
+    }
+
+    private User buildUser(String email) {
+        User u = new User(); u.setName("Test"); u.setEmail(email);
+        u.setPassword("hashed"); u.setProviderName("local"); u.setEmailVerified(true);
+        return u;
+    }
+    private Organization buildOrg(String name, User owner) {
+        Organization o = new Organization(); o.setName(name);
+        o.setSlug(name.toLowerCase().replace(" ","-")+"-"+UUID.randomUUID()); o.setOwner(owner);
+        return o;
+    }
+}

--- a/src/test/java/com/mockify/backend/security/AuthorizationMatrixTest.java
+++ b/src/test/java/com/mockify/backend/security/AuthorizationMatrixTest.java
@@ -1,5 +1,6 @@
 package com.mockify.backend.security;
 
+import com.mockify.backend.common.enums.MemberRole;
 import com.mockify.backend.common.enums.UserRole;
 import com.mockify.backend.dto.request.organization.UpdateOrganizationRequest;
 import com.mockify.backend.dto.request.record.CreateMockRecordRequest;
@@ -73,6 +74,7 @@ class AuthorizationMatrixTest {
     @Autowired ProjectRepository      projectRepository;
     @Autowired MockSchemaRepository   mockSchemaRepository;
     @Autowired MockRecordRepository   mockRecordRepository;
+    @Autowired OrganizationMemberRepository organizationMemberRepository;
 
     @MockitoBean
     EndpointService endpointService;
@@ -103,7 +105,12 @@ class AuthorizationMatrixTest {
         admin = userRepository.save(buildUser("admin@test.com", UserRole.ADMIN));
 
         orgA = organizationRepository.save(buildOrg("Alice Org", alice));
+        organizationMemberRepository.save(OrganizationMember.builder()
+                .organization(orgA).user(alice).role(MemberRole.OWNER).joinedAt(LocalDateTime.now()).build());
+
         orgB = organizationRepository.save(buildOrg("Bob Org",   bob));
+        organizationMemberRepository.save(OrganizationMember.builder()
+                .organization(orgB).user(bob).role(MemberRole.OWNER).joinedAt(LocalDateTime.now()).build());
 
         projectA = projectRepository.save(buildProject("Alice Project", orgA));
         projectB = projectRepository.save(buildProject("Bob Project",   orgB));

--- a/src/test/java/com/mockify/backend/security/MembershipPermissionEvaluatorTest.java
+++ b/src/test/java/com/mockify/backend/security/MembershipPermissionEvaluatorTest.java
@@ -1,0 +1,134 @@
+package com.mockify.backend.security;
+
+import com.mockify.backend.common.enums.MemberRole;
+import com.mockify.backend.model.*;
+import com.mockify.backend.repository.*;
+import com.mockify.backend.service.MockSchemaService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class MembershipPermissionEvaluatorTest {
+
+    @Autowired MockSchemaService mockSchemaService;
+    @Autowired MockSchemaRepository mockSchemaRepository;
+    @Autowired ProjectRepository projectRepository;
+    @Autowired OrganizationRepository organizationRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired OrganizationMemberRepository memberRepository;
+    @MockitoBean com.mockify.backend.service.EndpointService endpointService;
+
+    private User owner;
+    private Organization organization;
+    private Project project;
+    private MockSchema schema;
+
+    @BeforeEach
+    void setUp() {
+        owner   = userRepository.save(buildUser("perm-owner@test.com"));
+        organization     = organizationRepository.save(buildOrg("Perm Test Org", owner));
+        project = projectRepository.save(buildProject("Perm Project", organization));
+        schema  = mockSchemaRepository.save(buildSchema("Perm Schema", project));
+
+        // Enroll owner
+        memberRepository.save(OrganizationMember.builder()
+                .organization(organization).user(owner).role(MemberRole.OWNER).joinedAt(LocalDateTime.now()).build());
+    }
+
+    @Test
+    void owner_can_read_schema() {
+        authenticateAsJwt(owner.getId());
+        assertThatNoException().isThrownBy(
+                () -> mockSchemaService.getSchemaById(owner.getId(), schema.getId()));
+    }
+
+    @Test
+    void developer_member_can_read_schema() {
+        User dev = userRepository.save(buildUser("dev@test.com"));
+        memberRepository.save(OrganizationMember.builder()
+                .organization(organization).user(dev).role(MemberRole.DEVELOPER).joinedAt(LocalDateTime.now()).build());
+
+        authenticateAsJwt(dev.getId());
+        assertThatNoException().isThrownBy(
+                () -> mockSchemaService.getSchemaById(dev.getId(), schema.getId()));
+    }
+
+    @Test
+    void viewer_member_cannot_delete_schema() {
+        User viewer = userRepository.save(buildUser("viewer@test.com"));
+        memberRepository.save(OrganizationMember.builder()
+                .organization(organization).user(viewer).role(MemberRole.VIEWER).joinedAt(LocalDateTime.now()).build());
+
+        authenticateAsJwt(viewer.getId());
+        assertThatThrownBy(
+                () -> mockSchemaService.deleteSchema(viewer.getId(), schema.getId()))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void non_member_jwt_cannot_read_schema() {
+        User stranger = userRepository.save(buildUser("stranger@test.com"));
+        authenticateAsJwt(stranger.getId());
+        assertThatThrownBy(
+                () -> mockSchemaService.getSchemaById(stranger.getId(), schema.getId()))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void developer_cannot_delete_schema() {
+        User dev = userRepository.save(buildUser("dev2@test.com"));
+        memberRepository.save(OrganizationMember.builder()
+                .organization(organization).user(dev).role(MemberRole.DEVELOPER).joinedAt(LocalDateTime.now()).build());
+
+        authenticateAsJwt(dev.getId());
+        assertThatThrownBy(
+                () -> mockSchemaService.deleteSchema(dev.getId(), schema.getId()))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    private void authenticateAsJwt(UUID userId) {
+        var principal = org.springframework.security.core.userdetails.User
+                .withUsername(userId.toString()).password("")
+                .authorities(new SimpleGrantedAuthority("ROLE_USER")).build();
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
+    }
+
+    private User buildUser(String email) {
+        User u = new User(); u.setName("Test"); u.setEmail(email);
+        u.setPassword("hashed"); u.setProviderName("local"); u.setEmailVerified(true);
+        return u;
+    }
+    private Organization buildOrg(String name, User owner) {
+        Organization o = new Organization(); o.setName(name);
+        o.setSlug(name.toLowerCase().replace(" ","-")+"-"+UUID.randomUUID()); o.setOwner(owner);
+        return o;
+    }
+    private Project buildProject(String name, Organization org) {
+        Project p = new Project(); p.setName(name);
+        p.setSlug(name.toLowerCase().replace(" ","-")+"-"+UUID.randomUUID()); p.setOrganization(org);
+        return p;
+    }
+    private MockSchema buildSchema(String name, Project project) {
+        MockSchema s = new MockSchema(); s.setName(name);
+        s.setSlug(name.toLowerCase().replace(" ","-")+"-"+UUID.randomUUID());
+        s.setSchemaJson(Map.of("field", "string")); s.setProject(project);
+        return s;
+    }
+}

--- a/src/test/java/com/mockify/backend/service/OrganizationMemberServiceIntegrationTest.java
+++ b/src/test/java/com/mockify/backend/service/OrganizationMemberServiceIntegrationTest.java
@@ -92,6 +92,28 @@ class OrganizationMemberServiceIntegrationTest {
                 () -> memberService.changeMemberRole(member.getId(), org.getId(), owner.getId(), req));
     }
 
+    @Test
+    void owner_cannot_change_own_role() {
+        ChangeMemberRoleRequest req = new ChangeMemberRoleRequest();
+        req.setRole(MemberRole.ADMIN);
+        assertThrows(BadRequestException.class,
+                () -> memberService.changeMemberRole(
+                        owner.getId(), org.getId(), owner.getId(), req));
+    }
+
+    @Test
+    void admin_cannot_change_own_role() {
+        memberRepo.save(OrganizationMember.builder()
+                .organization(org).user(member).role(MemberRole.ADMIN)
+                .joinedAt(LocalDateTime.now()).build());
+
+        ChangeMemberRoleRequest req = new ChangeMemberRoleRequest();
+        req.setRole(MemberRole.DEVELOPER);
+        assertThrows(BadRequestException.class,
+                () -> memberService.changeMemberRole(
+                        member.getId(), org.getId(), member.getId(), req));
+    }
+
     // ── removeMember ──────────────────────────────────────────────────────────
 
     @Test
@@ -154,6 +176,14 @@ class OrganizationMemberServiceIntegrationTest {
         req.setNewOwnerId(owner.getId());
         assertThrows(ForbiddenException.class,
                 () -> memberService.transferOwnership(member.getId(), org.getId(), req));
+    }
+
+    @Test
+    void transfer_to_self_throws_bad_request() {
+        TransferOwnershipRequest req = new TransferOwnershipRequest();
+        req.setNewOwnerId(owner.getId());
+        assertThrows(BadRequestException.class,
+                () -> memberService.transferOwnership(owner.getId(), org.getId(), req));
     }
 
     // ── acceptInvitation token hashing ────────────────────────────────────────

--- a/src/test/java/com/mockify/backend/service/OrganizationMemberServiceIntegrationTest.java
+++ b/src/test/java/com/mockify/backend/service/OrganizationMemberServiceIntegrationTest.java
@@ -1,0 +1,212 @@
+package com.mockify.backend.service;
+
+import com.mockify.backend.common.enums.MemberRole;
+import com.mockify.backend.dto.request.member.*;
+import com.mockify.backend.dto.response.member.MemberResponse;
+import com.mockify.backend.exception.BadRequestException;
+import com.mockify.backend.exception.ForbiddenException;
+import com.mockify.backend.model.*;
+import com.mockify.backend.repository.*;
+import com.mockify.backend.util.InvitationTokenUtil;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class OrganizationMemberServiceIntegrationTest {
+
+    @Autowired OrganizationMemberService memberService;
+    @Autowired OrganizationMemberRepository memberRepo;
+    @Autowired OrganizationInvitationRepository invitationRepo;
+    @Autowired UserRepository userRepo;
+    @Autowired OrganizationRepository orgRepo;
+
+    private User owner;
+    private User member;
+    private User outsider;
+    private Organization org;
+
+    @BeforeEach
+    void setUp() {
+        owner    = userRepo.save(buildUser("owner@test.com"));
+        member   = userRepo.save(buildUser("member@test.com"));
+        outsider = userRepo.save(buildUser("outsider@test.com"));
+        org      = orgRepo.save(buildOrg("Test Org", owner));
+
+        // Seed owner as OWNER member (as the service/migration would do)
+        memberRepo.save(OrganizationMember.builder()
+                .organization(org).user(owner).role(MemberRole.OWNER).joinedAt(LocalDateTime.now()).build());
+    }
+
+    // ── listMembers ────────────────────────────────────────────────────────────
+
+    @Test
+    void listMembers_returns_all_members() {
+        memberRepo.save(OrganizationMember.builder()
+                .organization(org).user(member).role(MemberRole.DEVELOPER).joinedAt(LocalDateTime.now()).build());
+
+        List<MemberResponse> list = memberService.listMembers(owner.getId(), org.getId());
+        assertEquals(2, list.size());
+    }
+
+    @Test
+    void listMembers_throws_when_not_a_member() {
+        assertThrows(ForbiddenException.class,
+                () -> memberService.listMembers(outsider.getId(), org.getId()));
+    }
+
+    // ── changeMemberRole ───────────────────────────────────────────────────────
+
+    @Test
+    void owner_can_promote_developer_to_admin() {
+        memberRepo.save(OrganizationMember.builder()
+                .organization(org).user(member).role(MemberRole.DEVELOPER).joinedAt(LocalDateTime.now()).build());
+
+        ChangeMemberRoleRequest req = new ChangeMemberRoleRequest();
+        req.setRole(MemberRole.ADMIN);
+        MemberResponse updated = memberService.changeMemberRole(owner.getId(), org.getId(), member.getId(), req);
+
+        assertEquals(MemberRole.ADMIN, updated.getRole());
+    }
+
+    @Test
+    void cannot_promote_to_own_role_or_above() {
+        // Seed member as ADMIN
+        memberRepo.save(OrganizationMember.builder()
+                .organization(org).user(member).role(MemberRole.ADMIN).joinedAt(LocalDateTime.now()).build());
+
+        // owner is OWNER — cannot be changed
+        ChangeMemberRoleRequest req = new ChangeMemberRoleRequest();
+        req.setRole(MemberRole.ADMIN);
+        assertThrows(ForbiddenException.class,
+                () -> memberService.changeMemberRole(member.getId(), org.getId(), owner.getId(), req));
+    }
+
+    // ── removeMember ──────────────────────────────────────────────────────────
+
+    @Test
+    void owner_can_remove_developer() {
+        memberRepo.save(OrganizationMember.builder()
+                .organization(org).user(member).role(MemberRole.DEVELOPER).joinedAt(LocalDateTime.now()).build());
+
+        memberService.removeMember(owner.getId(), org.getId(), member.getId());
+
+        assertFalse(memberRepo.existsByOrganizationIdAndUserId(org.getId(), member.getId()));
+    }
+
+    @Test
+    void cannot_remove_self_via_removeMember() {
+        assertThrows(BadRequestException.class,
+                () -> memberService.removeMember(owner.getId(), org.getId(), owner.getId()));
+    }
+
+    // ── leaveOrganization ─────────────────────────────────────────────────────
+
+    @Test
+    void member_can_leave() {
+        memberRepo.save(OrganizationMember.builder()
+                .organization(org).user(member).role(MemberRole.DEVELOPER).joinedAt(LocalDateTime.now()).build());
+
+        memberService.leaveOrganization(member.getId(), org.getId());
+
+        assertFalse(memberRepo.existsByOrganizationIdAndUserId(org.getId(), member.getId()));
+    }
+
+    @Test
+    void owner_cannot_leave_without_transferring_first() {
+        assertThrows(BadRequestException.class,
+                () -> memberService.leaveOrganization(owner.getId(), org.getId()));
+    }
+
+    // ── transferOwnership ─────────────────────────────────────────────────────
+
+    @Test
+    void owner_can_transfer_to_existing_member() {
+        memberRepo.save(OrganizationMember.builder()
+                .organization(org).user(member).role(MemberRole.ADMIN).joinedAt(LocalDateTime.now()).build());
+
+        TransferOwnershipRequest req = new TransferOwnershipRequest();
+        req.setNewOwnerId(member.getId());
+        memberService.transferOwnership(owner.getId(), org.getId(), req);
+
+        assertEquals(MemberRole.OWNER,
+                memberRepo.findRoleByOrganizationIdAndUserId(org.getId(), member.getId()).orElseThrow());
+        assertEquals(MemberRole.ADMIN,
+                memberRepo.findRoleByOrganizationIdAndUserId(org.getId(), owner.getId()).orElseThrow());
+    }
+
+    @Test
+    void non_owner_cannot_transfer() {
+        memberRepo.save(OrganizationMember.builder()
+                .organization(org).user(member).role(MemberRole.ADMIN).joinedAt(LocalDateTime.now()).build());
+
+        TransferOwnershipRequest req = new TransferOwnershipRequest();
+        req.setNewOwnerId(owner.getId());
+        assertThrows(ForbiddenException.class,
+                () -> memberService.transferOwnership(member.getId(), org.getId(), req));
+    }
+
+    // ── acceptInvitation token hashing ────────────────────────────────────────
+
+    @Test
+    void accept_invitation_with_correct_token_adds_member() {
+        String rawToken = UUID.randomUUID().toString();
+
+        invitationRepo.save(OrganizationInvitation.builder()
+                .organization(org)
+                .email(outsider.getEmail())
+                .role(MemberRole.DEVELOPER)
+                .tokenHash(InvitationTokenUtil.hash(rawToken))
+                .invitedBy(owner)
+                .expiresAt(LocalDateTime.now().plusHours(48))
+                .build());
+
+        memberService.acceptInvitation(rawToken, outsider.getId());
+
+        assertTrue(memberRepo.existsByOrganizationIdAndUserId(org.getId(), outsider.getId()));
+    }
+
+    @Test
+    void accept_invitation_with_wrong_token_throws() {
+        String rawToken = UUID.randomUUID().toString();
+
+        invitationRepo.save(OrganizationInvitation.builder()
+                .organization(org)
+                .email(outsider.getEmail())
+                .role(MemberRole.DEVELOPER)
+                .tokenHash(InvitationTokenUtil.hash(rawToken))
+                .invitedBy(owner)
+                .expiresAt(LocalDateTime.now().plusHours(48))
+                .build());
+
+        assertThrows(Exception.class,
+                () -> memberService.acceptInvitation("wrong-token", outsider.getId()));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private User buildUser(String email) {
+        User u = new User();
+        u.setName("Test"); u.setEmail(email);
+        u.setPassword("hashed"); u.setProviderName("local"); u.setEmailVerified(true);
+        return u;
+    }
+
+    private Organization buildOrg(String name, User owner) {
+        Organization o = new Organization();
+        o.setName(name);
+        o.setSlug(name.toLowerCase().replace(" ", "-") + "-" + UUID.randomUUID());
+        o.setOwner(owner);
+        return o;
+    }
+}

--- a/src/test/java/com/mockify/backend/util/InvitationTokenUtilTest.java
+++ b/src/test/java/com/mockify/backend/util/InvitationTokenUtilTest.java
@@ -1,0 +1,32 @@
+package com.mockify.backend.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class InvitationTokenUtilTest {
+
+    @Test
+    void hash_is_deterministic_for_same_input() {
+        String token = "fixed-token";
+        String hash1 = InvitationTokenUtil.hash(token);
+        String hash2 = InvitationTokenUtil.hash(token);
+
+        assertEquals(hash1, hash2);
+    }
+
+    @Test
+    void different_inputs_produce_different_hashes() {
+        String hash1 = InvitationTokenUtil.hash("token-1");
+        String hash2 = InvitationTokenUtil.hash("token-2");
+
+        assertNotEquals(hash1, hash2);
+    }
+
+    @Test
+    void hash_is_64_character_hex_string() {
+        String hash = InvitationTokenUtil.hash("test");
+
+        assertEquals(64, hash.length());
+        assertTrue(hash.matches("[0-9a-f]{64}"));
+    }
+}


### PR DESCRIPTION
## Team collaboration — org membership, workspace roles and invitations

### Summary

Adds a full membership system to organizations so users can collaborate in teams.
Previously every org was accessible only by its single owner. 
This PR introduces four roles (OWNER / ADMIN / DEVELOPER / VIEWER), an email-based invitation flow,
role-enforced authorization across all existing resources, and a complete member management API.

---

### What changed

#### Database
- `V12__organization_members.sql` — two new tables: `organization_members`
  (role, joined_at, invited_by) and `organization_invitations` (email, SHA-256 token hash,
  expires_at, status). Existing orgs backfilled: each owner gets an `OWNER` row.

#### Domain model
- `MemberRole` enum — `VIEWER / DEVELOPER / ADMIN / OWNER` with three methods:
    - Explicit `level` field 
    - `atLeast(MemberRole)`, `higherThan(MemberRole)` — evaluator-side checks
    - `canManage(MemberRole)` — actor can manage target only if actor outranks target and target is not OWNER
    - `canInviteAs(MemberRole)` — actor can invite at role only if actor is ADMIN+ and role is strictly below actor
    - Fully decoupled from `ApiKeyPermission` types
- `OrganizationMember` and `OrganizationInvitation` JPA entities
- `InvitationTokenUtil` — SHA-256 hashing (not bcrypt) for deterministic DB lookup

#### Auth changes (breaking to old implicit ownership)
- `MockifyPermissionEvaluator.evaluateJwt()` now resolves `MemberRole` from
  `organization_members` instead of comparing `owner.id`. **A valid JWT from a
  non-member is now correctly denied.** Existing owner sessions continue to work
  because the backfill migration created their OWNER member row.
- `OrganizationServiceImpl.createOrganization()` auto-creates the OWNER member row.
- `OrganizationServiceImpl.getMyOrganizations()` returns all orgs the user is a
  member of (not just owned), with `userRole` populated on each response.

#### Service
Full lifecycle via `OrganizationMemberService`:
`inviteMember` · `acceptInvitation` · `listMembers` · `listPendingInvitations` ·
`changeMemberRole` · `removeMember` · `cancelInvitation` · `leaveOrganization` ·
`transferOwnership`

Key business rules enforced:
- Invitation sends to email, token hashed in DB. Raw token in link only.
- Email mismatch between invitee account and invitation → 403
- OWNER must transfer before leaving
- No one can manage or invite to a role ≥ their own
- No one can remove or change the OWNER role (except via transfer-ownership)

#### API
8 new endpoints under `POST /api/organizations/{org}/members/*`:

| Method | Path | Auth | Who |
|---|---|---|---|
| `GET` | `/members` | JWT or API key | any member |
| `GET` | `/members/invitations` | JWT | ADMIN+ |
| `POST` | `/members/invite` | JWT only | ADMIN+ |
| `POST` | `/members/invitations/accept` | JWT only | invitee |
| `DELETE` | `/members/invitations/{id}` | JWT only | ADMIN+ |
| `PUT` | `/members/{userId}/role` | JWT only | ADMIN+ |
| `DELETE` | `/members/{userId}` | JWT only | ADMIN+ |
| `POST` | `/members/leave` | JWT only | any member |
| `POST` | `/members/transfer-ownership` | JWT only | OWNER |

#### Email
New `sendInvitationEmail()` on `MailService` with HTML template.
Follows the existing `MailServiceImpl` pattern.

#### Housekeeping
`InvitationCleanupScheduler` prunes expired pending invitations hourly.

---

### Tests

| Test class | Type | Count | What it covers |
|---|---|---|---|
| `MemberRoleTest` | Unit (no Spring) | 14 | Permission hierarchy, canManage, canInviteAs |
| `OrganizationMemberServiceTest` | Unit (Mockito) | 11 | Business rules: escalation, OWNER leave, transfer |
| `MembershipPermissionIntegrationTest` | Integration | 5 | Real evaluator + DB: VIEWER/OWNER/stranger access |
| `OrganizationMemberControllerTest` | MockMvc | 8 | HTTP status codes, API key rejection, validation |


---

### Migration notes

**Nothing breaks for existing users.** The `V12` migration backfills an `OWNER`
member row for every existing organization owner. From that point, the permission
evaluator continues to grant them full access via their membership rather than
via the legacy ownership field. The `owner_id` column is preserved in the
`organizations` table for backward compatibility and is updated on ownership
transfer.

**API consumers:** `GET /api/organizations` response now includes a `userRole`
field on each object. Existing consumers that ignore unknown fields are unaffected.

---

### What is NOT in this PR

- Frontend UI 
- Per-project member overrides (future enhancement)

---

### Checklist

- [x] Flyway migration tested on clean DB and existing DB with data
- [x] All existing test suites pass with no modifications
- [x] New business rules covered by unit tests (no Spring context)
- [x] Auth integration verified by integration test against real DB
- [x] HTTP layer verified by MockMvc tests
- [x] API key callers correctly blocked from all JWT-only member management endpoints
- [x] Invitation token stored as SHA-256 hash, raw token never persisted
- [x] Cleanup scheduler follows existing project conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role-based organization membership (Viewer, Developer, Admin, Owner) with member listing, invites, invite acceptance via token links, ownership transfer, and invitation emails.

* **Documentation**
  * API docs updated with "Organization Members" and "Invitations" sections.

* **Chores**
  * Scheduled cleanup job for expired invitations and database migration to add membership & invitation support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->