### PR TITLE
Fix a compilation error in `SecurityConfig.securityFilterChain()` caused by a missing semicolon.

### DIFF
--- a/src/main/java/com/mockify/backend/config/SecurityConfig.java
+++ b/src/main/java/com/mockify/backend/config/SecurityConfig.java
@@ -124,7 +124,7 @@ public class SecurityConfig {
                 .addFilterAfter(rateLimitFilter, ApiKeyAuthenticationFilter.class)
 
                 // 4. API Key-specific rate limiting (per key quotas, stricter limits)
-                .addFilterAfter(apiKeyRateLimitFilter, RateLimitFilter.class)
+                .addFilterAfter(apiKeyRateLimitFilter, RateLimitFilter.class);
 
         return http.build();
     }


### PR DESCRIPTION
## Summary
Fix a compilation error in `SecurityConfig.securityFilterChain()` caused by a missing semicolon.

## Changes
- Added the missing `;` after the final `.addFilterAfter(...)` call.
- Ensured the filter chain statement is properly terminated before `return http.build();`.

## Impact
- Fixes Java compilation failure.
- No runtime or functional behavior changes.
- Authentication and filter ordering remain unchanged.

## Testing
- Verified project builds successfully.
- Confirmed Spring Security configuration compiles without syntax errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a compilation issue in the security configuration that was preventing the application from building successfully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sadabazhar/mockify-backend/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->