### PR TITLE
feat(sandbox): foundation, core service & request interceptor

### DIFF
--- a/src/main/java/com/mockify/backend/common/enums/UserRole.java
+++ b/src/main/java/com/mockify/backend/common/enums/UserRole.java
@@ -2,5 +2,23 @@ package com.mockify.backend.common.enums;
 
 public enum UserRole {
     USER,
-    ADMIN
+    ADMIN,
+
+    /**
+     * Ephemeral guest role for sandbox sessions.
+     *
+     * A GUEST user:
+     * - has no email, no password, no provider
+     * - cannot log in via /api/auth/login
+     * - cannot request a password reset
+     * - owns exactly one sandbox organization
+     * - is automatically deleted when the sandbox org expires
+     *
+     * Code that checks for authorization should treat GUEST
+     * identically to USER for resource-level access
+     * (the sandbox org IS their org — full ownership applies).
+     * Code that manages account identity (email, password, login)
+     * must explicitly exclude GUEST.
+     */
+    GUEST
 }

--- a/src/main/java/com/mockify/backend/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/mockify/backend/config/PasswordEncoderConfig.java
@@ -1,0 +1,23 @@
+package com.mockify.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Defines the PasswordEncoder bean in isolation.
+ *
+ * Kept separate from SecurityConfig intentionally: PasswordEncoder is used
+ * by AuthServiceImpl, SandboxServiceImpl, and OAuth2AuthenticationSuccessHandler.
+ * Defining it in SecurityConfig creates a circular dependency whenever any of
+ * those services are transitively required by a SecurityConfig dependency.
+ */
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(10);
+    }
+}

--- a/src/main/java/com/mockify/backend/config/SecurityConfig.java
+++ b/src/main/java/com/mockify/backend/config/SecurityConfig.java
@@ -124,7 +124,7 @@ public class SecurityConfig {
                 .addFilterAfter(rateLimitFilter, ApiKeyAuthenticationFilter.class)
 
                 // 4. API Key-specific rate limiting (per key quotas, stricter limits)
-                .addFilterAfter(apiKeyRateLimitFilter, RateLimitFilter.class)
+                .addFilterAfter(apiKeyRateLimitFilter, RateLimitFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/mockify/backend/config/SecurityConfig.java
+++ b/src/main/java/com/mockify/backend/config/SecurityConfig.java
@@ -46,11 +46,6 @@ public class SecurityConfig {
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder(10);
-    }
-
-    @Bean
     public AuthenticationManager authenticationManager(
             AuthenticationConfiguration authenticationConfiguration) throws Exception {
         return authenticationConfiguration.getAuthenticationManager();

--- a/src/main/java/com/mockify/backend/config/SecurityConfig.java
+++ b/src/main/java/com/mockify/backend/config/SecurityConfig.java
@@ -1,10 +1,6 @@
 package com.mockify.backend.config;
 
-import com.mockify.backend.security.ApiKeyAuthenticationFilter;
-import com.mockify.backend.security.ApiKeyRateLimitFilter;
-import com.mockify.backend.security.CustomAuthenticationEntryPoint;
-import com.mockify.backend.security.JwtAuthenticationFilter;
-import com.mockify.backend.security.RateLimitFilter;
+import com.mockify.backend.security.*;
 import com.mockify.backend.security.oauth2.CustomOAuth2UserService;
 import com.mockify.backend.security.oauth2.OAuth2AuthenticationSuccessHandler;
 import lombok.RequiredArgsConstructor;
@@ -26,14 +22,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
 
-/**
- *
- * Authentication Flow:
- * 1. JWT Filter checks for Bearer token
- * 2. API Key Filter checks for X-API-Key header
- *
- * Priority: JWT > API Key
- */
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
@@ -43,6 +31,7 @@ public class SecurityConfig {
     private final RateLimitFilter rateLimitFilter;
     private final ApiKeyAuthenticationFilter apiKeyAuthenticationFilter;
     private final ApiKeyRateLimitFilter apiKeyRateLimitFilter;
+    private final SandboxRequestInterceptor sandboxRequestInterceptor;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
@@ -55,7 +44,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http,
                                                    CustomOAuth2UserService customOAuth2UserService,
                                                    OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler) throws Exception {
-        http
+            http
                 .csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session ->
@@ -72,6 +61,15 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/api/mock/**").permitAll()
                         .requestMatchers("/api/endpoints/lookup/**").permitAll()
+
+
+                        // ----- Sandbox endpoints ------------------
+                        // No auth: anyone can start a sandbox or follow a verify link
+                        .requestMatchers("/api/sandbox/start").permitAll()
+                        .requestMatchers("/api/sandbox/resume").permitAll()
+                        .requestMatchers("/api/sandbox/convert/verify").permitAll()
+                        // Requires GUEST JWT: only authenticated sandbox users can initiate conversion
+                        .requestMatchers("/api/sandbox/convert").authenticated()
 
                         // Admin-only endpoints
                         .requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")
@@ -119,7 +117,11 @@ public class SecurityConfig {
                 .addFilterAfter(rateLimitFilter, ApiKeyAuthenticationFilter.class)
 
                 // 4. API Key-specific rate limiting (per key quotas, stricter limits)
-                .addFilterAfter(apiKeyRateLimitFilter, RateLimitFilter.class);
+                .addFilterAfter(apiKeyRateLimitFilter, RateLimitFilter.class)
+
+                // 5. Sandbox session validation (GUEST users only)
+                // Runs last: auth + rate limiting both happen before session check
+                    .addFilterAfter(sandboxRequestInterceptor, ApiKeyRateLimitFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/mockify/backend/dto/response/error/ErrorResponse.java
+++ b/src/main/java/com/mockify/backend/dto/response/error/ErrorResponse.java
@@ -1,5 +1,6 @@
 package com.mockify.backend.dto.response.error;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,4 +14,19 @@ public class ErrorResponse {
     private String error;
     private String message;
     private String path;
+
+    /**
+     * Machine-readable error code for frontend handling.
+     * Null for most errors — only set when the frontend needs
+     * to take a specific action beyond displaying the message.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String errorCode;
+
+    /**
+     * URL the frontend should direct the user to when errorCode is set.
+     * Null for all standard errors.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String actionUrl;
 }

--- a/src/main/java/com/mockify/backend/dto/response/sandbox/SandboxCreationResult.java
+++ b/src/main/java/com/mockify/backend/dto/response/sandbox/SandboxCreationResult.java
@@ -1,0 +1,28 @@
+package com.mockify.backend.dto.response.sandbox;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.ResponseCookie;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class SandboxCreationResult {
+
+    /** Short-lived JWT for immediate API access (1 hour). */
+    private String accessToken;
+
+    /** Token expiry in milliseconds, matching JWT_ACCESS_EXPIRATION. */
+    private long expiresIn;
+
+    /**
+     * HttpOnly cookie carrying the long-lived sandbox session token.
+     * The controller sets this as a response header.
+     * Not serialized in the JSON response body.
+     */
+    private transient ResponseCookie sandboxCookie;
+
+    /** Describes the auto-provisioned workspace. */
+    private SandboxWorkspace workspace;
+}

--- a/src/main/java/com/mockify/backend/dto/response/sandbox/SandboxResumeResult.java
+++ b/src/main/java/com/mockify/backend/dto/response/sandbox/SandboxResumeResult.java
@@ -1,0 +1,11 @@
+package com.mockify.backend.dto.response.sandbox;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SandboxResumeResult {
+    private String accessToken;
+    private long expiresIn;
+}

--- a/src/main/java/com/mockify/backend/dto/response/sandbox/SandboxSchemaInfo.java
+++ b/src/main/java/com/mockify/backend/dto/response/sandbox/SandboxSchemaInfo.java
@@ -1,0 +1,22 @@
+package com.mockify.backend.dto.response.sandbox;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class SandboxSchemaInfo {
+    private UUID schemaId;
+    private String name;
+    private String slug;
+
+    /** Full public URL to fetch records for this schema. */
+    private String apiUrl;
+
+    /** Number of pre-seeded records created at sandbox initialization. */
+    private int seedRecordCount;
+}

--- a/src/main/java/com/mockify/backend/dto/response/sandbox/SandboxWorkspace.java
+++ b/src/main/java/com/mockify/backend/dto/response/sandbox/SandboxWorkspace.java
@@ -1,0 +1,29 @@
+package com.mockify.backend.dto.response.sandbox;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class SandboxWorkspace {
+
+    /** Slug of the auto-created sandbox organization. */
+    private String orgSlug;
+
+    /** Slug of the auto-created demo project. */
+    private String projectSlug;
+
+    /** Pre-seeded schemas with their public API URLs. */
+    private List<SandboxSchemaInfo> schemas;
+
+    /**
+     * Base URL for public mock access.
+     * Pattern: /api/mock/{orgSlug}/{projectSlug}
+     * Append /{schemaSlug}/records to get a ready-to-use endpoint.
+     */
+    private String baseMockUrl;
+}

--- a/src/main/java/com/mockify/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mockify/backend/exception/GlobalExceptionHandler.java
@@ -8,9 +8,28 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(SandboxExpiredException.class)
+    public ResponseEntity<Map<String, Object>> handleSandboxExpired(
+            SandboxExpiredException ex,
+            HttpServletRequest req) {
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", HttpStatus.GONE.value());
+        body.put("error", "Sandbox Expired");
+        body.put("errorCode", "SANDBOX_EXPIRED");
+        body.put("message", ex.getMessage());
+        body.put("path", req.getRequestURI());
+        body.put("convertUrl", "/api/sandbox/convert");
+
+        return new ResponseEntity<>(body, HttpStatus.GONE);
+    }
 
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<ErrorResponse> handleBaseException(BaseException ex, HttpServletRequest req) {

--- a/src/main/java/com/mockify/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mockify/backend/exception/GlobalExceptionHandler.java
@@ -14,21 +14,27 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    /**
+     * Handles sandbox session expiry with a machine-readable error code.
+     * Must be declared before the generic BaseException handler so Spring
+     * picks the most specific handler.
+     */
     @ExceptionHandler(SandboxExpiredException.class)
-    public ResponseEntity<Map<String, Object>> handleSandboxExpired(
+    public ResponseEntity<ErrorResponse> handleSandboxExpired(
             SandboxExpiredException ex,
             HttpServletRequest req) {
 
-        Map<String, Object> body = new LinkedHashMap<>();
-        body.put("timestamp", LocalDateTime.now());
-        body.put("status", HttpStatus.GONE.value());
-        body.put("error", "Sandbox Expired");
-        body.put("errorCode", "SANDBOX_EXPIRED");
-        body.put("message", ex.getMessage());
-        body.put("path", req.getRequestURI());
-        body.put("convertUrl", "/api/sandbox/convert");
+        ErrorResponse response = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.GONE.value())
+                .error("Sandbox Expired")
+                .message(ex.getMessage())
+                .path(req.getRequestURI())
+                .errorCode("SANDBOX_EXPIRED")
+                .actionUrl("/api/sandbox/convert")
+                .build();
 
-        return new ResponseEntity<>(body, HttpStatus.GONE);
+        return new ResponseEntity<>(response, HttpStatus.GONE);
     }
 
     @ExceptionHandler(BaseException.class)

--- a/src/main/java/com/mockify/backend/exception/SandboxExpiredException.java
+++ b/src/main/java/com/mockify/backend/exception/SandboxExpiredException.java
@@ -1,0 +1,22 @@
+package com.mockify.backend.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Thrown when a sandbox session has passed its hard expiry cap.
+ *
+ * HTTP 410 Gone is semantically correct here — the resource existed
+ * and is now permanently gone, unlike 401 (unauthenticated) or
+ * 403 (forbidden). The frontend intercepts 410 specifically to show
+ * the "convert to keep your work" prompt rather than a generic error.
+ */
+public class SandboxExpiredException extends BaseException {
+
+    public SandboxExpiredException() {
+        super("Your sandbox session has expired. Convert your account to keep your work.", HttpStatus.GONE);
+    }
+
+    public SandboxExpiredException(String message) {
+        super(message, HttpStatus.GONE);
+    }
+}

--- a/src/main/java/com/mockify/backend/model/Organization.java
+++ b/src/main/java/com/mockify/backend/model/Organization.java
@@ -6,7 +6,6 @@ import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @Entity
@@ -16,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Organization {
+
     @Id
     @GeneratedValue
     @Column(updatable = false, nullable = false)
@@ -38,13 +38,46 @@ public class Organization {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    /**
+     * True for organizations created as part of a sandbox session.
+     *
+     * Sandbox orgs are owned by GUEST users and are automatically
+     * deleted when expires_at passes. When a guest converts to a
+     * real account, this flag is set to false and expires_at is
+     * cleared — making the org indistinguishable from a real org.
+     *
+     * Invariant (enforced by DB CHECK constraint):
+     *   if isSandbox = true then expiresAt must not be null.
+     */
+    @Column(name = "is_sandbox", nullable = false)
+    private boolean isSandbox = false;
+
+    /**
+     * Sandbox expiry timestamp (null for real organizations).
+     * The cleanup scheduler deletes orgs where:
+     *   is_sandbox = true AND expires_at < NOW()
+     */
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
     @JsonIgnore
     @OneToMany(mappedBy = "organization", cascade = CascadeType.ALL)
     private Set<Project> projects = new HashSet<>();
 
-    @JsonIgnore
-    @OneToMany(mappedBy = "organization", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<OrganizationMember> members = new HashSet<>();
+    // -------------------------------------------------------------------------
+    // Lifecycle helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns true if this sandbox org has passed its expiry time.
+     * Always false for non-sandbox orgs.
+     */
+    public boolean isExpired() {
+        if (!isSandbox) {
+            return false;
+        }
+        return expiresAt != null && expiresAt.isBefore(LocalDateTime.now());
+    }
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/mockify/backend/model/User.java
+++ b/src/main/java/com/mockify/backend/model/User.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class User {
+
     @Id
     @GeneratedValue
     @Column(updatable = false, nullable = false)
@@ -24,14 +25,26 @@ public class User {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false, unique = true)
+    /**
+     * Nullable for GUEST (sandbox) users.
+     *
+     * Uniqueness is enforced at the DB level via a partial index
+     * (idx_users_email_unique_partial, WHERE email IS NOT NULL)
+     * rather than a JPA unique constraint — because Hibernate's
+     * @Column(unique=true) generates a blanket UNIQUE constraint
+     * which would reject two simultaneous null emails.
+     *
+     * Do NOT add unique=true here.
+     */
+    @Column(nullable = true)
     private String email;
 
     @Column(name = "email_verified", nullable = false)
     private boolean emailVerified = false;
 
+    @JsonIgnore
     @Column(name = "password")
-    private String password; // Now nullable for OAuth users
+    private String password;
 
     // Default role is USER to prevent accidental admin creation
     @Enumerated(EnumType.STRING)
@@ -62,9 +75,26 @@ public class User {
     @Column(name = "avatar_url", columnDefinition = "TEXT")
     private String avatarUrl;
 
+    /**
+     * HMAC-SHA256 hash of the sandbox opaque token.
+     * Stored as a Redis-fallback: if Redis is unavailable,
+     * sandbox token validation falls back to this column.
+     * Null for non-sandbox users.
+     */
+    @JsonIgnore
+    @Column(name = "sandbox_token_hash", length = 255)
+    private String sandboxTokenHash;
+
+    @Column(name = "sandbox_created_at")
+    private LocalDateTime sandboxCreatedAt;
+
     @JsonIgnore
     @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)
     private Set<Organization> organizations = new HashSet<>();
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
 
     @PrePersist
     protected void onCreate() {
@@ -79,5 +109,17 @@ public class User {
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();
+    }
+
+    // -------------------------------------------------------------------------
+    // Role helpers
+    // -------------------------------------------------------------------------
+
+    public boolean isGuest() {
+        return UserRole.GUEST == this.role;
+    }
+
+    public boolean isRealUser() {
+        return UserRole.USER == this.role || UserRole.ADMIN == this.role;
     }
 }

--- a/src/main/java/com/mockify/backend/repository/OrganizationRepository.java
+++ b/src/main/java/com/mockify/backend/repository/OrganizationRepository.java
@@ -52,4 +52,6 @@ public interface OrganizationRepository extends JpaRepository<Organization, UUID
      * Used to return only real (non-sandbox) orgs in the user-facing listing.
      */
     Page<Organization> findByOwnerIdAndIsSandboxFalse(UUID ownerId, Pageable pageable);
+
+    Optional<Organization> findByOwnerIdAndIsSandboxTrue(UUID ownerId);
 }

--- a/src/main/java/com/mockify/backend/repository/OrganizationRepository.java
+++ b/src/main/java/com/mockify/backend/repository/OrganizationRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -40,4 +41,15 @@ public interface OrganizationRepository extends JpaRepository<Organization, UUID
     Optional<Organization> findBySlug(String slug);
 
     boolean existsBySlug(String slug);
+
+    /**
+     * Used by the cleanup scheduler to find expired sandbox orgs.
+     * Backed by idx_organizations_sandbox_expiry partial index.
+     */
+    List<Organization> findByIsSandboxTrueAndExpiresAtBefore(LocalDateTime now);
+
+    /**
+     * Used to return only real (non-sandbox) orgs in the user-facing listing.
+     */
+    Page<Organization> findByOwnerIdAndIsSandboxFalse(UUID ownerId, Pageable pageable);
 }

--- a/src/main/java/com/mockify/backend/repository/UserRepository.java
+++ b/src/main/java/com/mockify/backend/repository/UserRepository.java
@@ -5,6 +5,8 @@ import com.mockify.backend.model.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -36,4 +38,35 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Page<User> findByRole(UserRole role, Pageable pageable);
 
     Page<User> findByEmailContainingIgnoreCaseAndRole(String email, UserRole role, Pageable pageable);
+
+    /**
+     * Find a guest user by the hash of their sandbox token.
+     * Used for Redis-fallback token validation.
+     */
+    Optional<User> findBySandboxTokenHash(String sandboxTokenHash);
+
+    /**
+     * Used by the cleanup scheduler to delete orphaned guest users
+     * (guests whose sandbox org has already been deleted).
+     */
+    @Modifying
+    @Query("""
+        DELETE FROM User u
+        WHERE u.role = com.mockify.backend.common.enums.UserRole.GUEST
+          AND NOT EXISTS (
+              SELECT 1 FROM Organization o WHERE o.owner.id = u.id
+          )
+    """)
+    int deleteOrphanedGuestUsers();
+
+    /**
+     * Admin listing — exclude GUEST accounts from user management views.
+     */
+    Page<User> findByEmailContainingIgnoreCaseAndRoleNot(
+            String email, UserRole role, Pageable pageable);
+
+    Page<User> findByRoleNot(UserRole role, Pageable pageable);
+
+    Page<User> findByEmailContainingIgnoreCaseAndRoleAndRoleNot(
+            String email, UserRole filterRole, UserRole excludeRole, Pageable pageable);
 }

--- a/src/main/java/com/mockify/backend/sandbox/PendingConversion.java
+++ b/src/main/java/com/mockify/backend/sandbox/PendingConversion.java
@@ -1,0 +1,31 @@
+package com.mockify.backend.sandbox;
+
+import lombok.*;
+
+import java.util.UUID;
+
+/**
+ * Stored in Redis under key: sandbox:convert:{verificationToken}
+ * TTL: 15 minutes
+ *
+ * Created by initiateSandboxConversion().
+ * Consumed atomically by completeSandboxConversion().
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PendingConversion {
+
+    private UUID userId;
+    private String email;
+    private String encodedPassword;
+
+    /**
+     * The original sandbox session token.
+     * Consumed (deleted from Redis) once conversion completes,
+     * preventing any future resume attempts on the converted account.
+     */
+    private String sandboxToken;
+}

--- a/src/main/java/com/mockify/backend/sandbox/SandboxSeedDataProvider.java
+++ b/src/main/java/com/mockify/backend/sandbox/SandboxSeedDataProvider.java
@@ -1,0 +1,100 @@
+package com.mockify.backend.sandbox;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Provides realistic pre-seeded record data for sandbox workspaces.
+ *
+ * Data is hardcoded here deliberately — it's presentation-layer content,
+ * not business data. Storing it in the DB would require a migration for
+ * every update and add operational overhead for no benefit.
+ *
+ * Values match the field types defined in the corresponding system templates
+ * (V10 migration). If a template schema changes, update these records too.
+ */
+@Component
+public class SandboxSeedDataProvider {
+
+    /**
+     * Template slugs to apply when creating a sandbox, in order.
+     * These must exist in schema_templates table (seeded in V10).
+     */
+    public static final List<String> DEFAULT_TEMPLATE_SLUGS =
+            List.of("user-profile", "product-item");
+
+    /**
+     * Returns seed records for a given template slug.
+     * Returns an empty list if the slug is unknown — seeding is
+     * best-effort and should not fail sandbox creation.
+     */
+    public List<Map<String, Object>> getSeedRecords(String templateSlug) {
+        return switch (templateSlug) {
+            case "user-profile" -> userProfileRecords();
+            case "product-item" -> productItemRecords();
+            default -> List.of();
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Seed data definitions
+    // -------------------------------------------------------------------------
+
+    private List<Map<String, Object>> userProfileRecords() {
+        return List.of(
+                Map.of(
+                        "id",        UUID.randomUUID().toString(),
+                        "name",      "Tony Stark",
+                        "email",     "ironman@newyork.com",
+                        "age",       50,
+                        "isActive",  true,
+                        "createdAt", "2025-01-15T10:30:00Z"
+                ),
+                Map.of(
+                        "id",        UUID.randomUUID().toString(),
+                        "name",      "Peter Parker",
+                        "email",     "spiderman@newyork.com",
+                        "age",       20,
+                        "isActive",  true,
+                        "createdAt", "2025-01-16T14:20:00Z"
+                ),
+                Map.of(
+                        "id",        UUID.randomUUID().toString(),
+                        "name",      "Victor Von Doom",
+                        "email",     "doctordoom@latveria.com",
+                        "age",       40,
+                        "isActive",  false,
+                        "createdAt", "2025-01-17T09:15:00Z"
+                )
+        );
+    }
+
+    private List<Map<String, Object>> productItemRecords() {
+        return List.of(
+                Map.of(
+                        "id",       UUID.randomUUID().toString(),
+                        "name",     "Wireless Headphones",
+                        "price",    79.99,
+                        "currency", "USD",
+                        "inStock",  true
+                ),
+                Map.of(
+                        "id",       UUID.randomUUID().toString(),
+                        "name",     "USB-C Hub 7-in-1",
+                        "price",    34.99,
+                        "currency", "USD",
+                        "inStock",  true
+                ),
+                Map.of(
+                        "id",       UUID.randomUUID().toString(),
+                        "name",     "Mechanical Keyboard",
+                        "price",    129.99,
+                        "currency", "USD",
+                        "inStock",  false
+                )
+        );
+    }
+}

--- a/src/main/java/com/mockify/backend/sandbox/SandboxSession.java
+++ b/src/main/java/com/mockify/backend/sandbox/SandboxSession.java
@@ -1,0 +1,45 @@
+package com.mockify.backend.sandbox;
+
+import lombok.*;
+
+import java.util.UUID;
+
+/**
+ * Stored in Redis under key: sandbox:session:{rawToken}
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SandboxSession {
+
+    private UUID userId;
+    private UUID organizationId;
+
+    /** Epoch ms when the sandbox was first created. Never changes. */
+    private long createdAtEpochMs;
+
+    /**
+     * Epoch ms of the absolute maximum lifetime.
+     * Rolling TTL cannot push beyond this cap.
+     * Equals createdAtEpochMs + 24 hours.
+     */
+    private long hardExpiresAtEpochMs;
+
+    // -------------------------------------------------------------------------
+    // Domain helpers
+    // -------------------------------------------------------------------------
+
+    public boolean isHardExpired() {
+        return System.currentTimeMillis() > hardExpiresAtEpochMs;
+    }
+
+    /**
+     * Remaining milliseconds until hard expiry.
+     * Returns 0 if already expired (never negative).
+     */
+    public long remainingMs() {
+        return Math.max(0, hardExpiresAtEpochMs - System.currentTimeMillis());
+    }
+}

--- a/src/main/java/com/mockify/backend/security/CookieUtil.java
+++ b/src/main/java/com/mockify/backend/security/CookieUtil.java
@@ -26,6 +26,16 @@ public class CookieUtil {
     @NotBlank
     private String sameSite;
 
+    // ── Sandbox token cookie config (bound from app.cookie.sandbox-token.*) ──
+    // These are set programmatically from SandboxServiceImpl
+    private String sandboxCookieName   = "sandbox_token";
+    private String sandboxCookiePath   = "/api/sandbox";
+    private long   sandboxCookieMaxAge = 86400L;  // 24h default
+
+    // =========================================================================
+    // Refresh token
+    // =========================================================================
+
     public ResponseCookie createRefreshToken(String token) {
         return ResponseCookie.from(name, token)
                 .httpOnly(true)
@@ -41,7 +51,36 @@ public class CookieUtil {
                 .httpOnly(true)
                 .secure(secure)
                 .path(path)
-                .maxAge(0) // To delete a cookie, the browser requires 0
+                .maxAge(0)
+                .sameSite(sameSite)
+                .build();
+    }
+
+    // =========================================================================
+    // Sandbox token
+    // =========================================================================
+
+    /**
+     * Creates the long-lived HttpOnly cookie that carries the sandbox
+     * session token. Scoped to /api/sandbox so it is only sent on
+     * sandbox-specific endpoints (resume, convert), not on every API call.
+     */
+    public ResponseCookie createSandboxTokenCookie(String rawToken) {
+        return ResponseCookie.from(sandboxCookieName, rawToken)
+                .httpOnly(true)
+                .secure(secure)
+                .path(sandboxCookiePath)
+                .maxAge(sandboxCookieMaxAge)
+                .sameSite(sameSite)
+                .build();
+    }
+
+    public ResponseCookie clearSandboxTokenCookie() {
+        return ResponseCookie.from(sandboxCookieName, "")
+                .httpOnly(true)
+                .secure(secure)
+                .path(sandboxCookiePath)
+                .maxAge(0)
                 .sameSite(sameSite)
                 .build();
     }

--- a/src/main/java/com/mockify/backend/security/SandboxRequestInterceptor.java
+++ b/src/main/java/com/mockify/backend/security/SandboxRequestInterceptor.java
@@ -1,0 +1,198 @@
+package com.mockify.backend.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mockify.backend.dto.response.error.ErrorResponse;
+import com.mockify.backend.sandbox.SandboxSession;
+import com.mockify.backend.service.SandboxService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Validates the sandbox session on every request made by a GUEST user.
+ *
+ * <h3>Responsibility</h3>
+ * <ul>
+ *   <li>Read {@code sandbox_token} from the HttpOnly cookie.</li>
+ *   <li>Look up the session in Redis via {@link SandboxService#getSession}.</li>
+ *   <li>Enforce the hard expiry cap — block the request with HTTP 410 if exceeded.</li>
+ *   <li>Roll the Redis TTL forward on every successful request (activity-based extension).</li>
+ * </ul>
+ *
+ * <h3>Filter position in the chain</h3>
+ * Runs after {@link ApiKeyRateLimitFilter} — authentication and rate limiting
+ * both happen before session validation so a GUEST user who exceeds their rate
+ * limit gets a 429, not a 410, which is the correct response ordering.
+ *
+ * <h3>Pass-through conditions</h3>
+ * <ol>
+ *   <li>Path matches {@link #SKIP_PATH_PATTERNS} — filter short-circuits immediately
+ *       via {@link #shouldNotFilter}.</li>
+ *   <li>Authenticated principal does not carry {@code ROLE_GUEST} — real users and
+ *       API key callers pass through without any Redis lookup.</li>
+ * </ol>
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SandboxRequestInterceptor extends OncePerRequestFilter {
+
+    static final String SANDBOX_COOKIE_NAME = "sandbox_token";
+
+    private static final String EXPIRED_ERROR_CODE = "SANDBOX_EXPIRED";
+    private static final String EXPIRED_MESSAGE =
+            "Your sandbox session has expired. Convert your account to keep your work.";
+    private static final String CONVERT_URL = "/api/sandbox/convert";
+
+    /**
+     * Paths skipped entirely — the filter body never runs for these.
+     * Sandbox-specific endpoints (/api/sandbox/**) handle their own
+     * token validation; skipping them here avoids redundant Redis lookups.
+     */
+    private static final List<String> SKIP_PATH_PATTERNS = List.of(
+            "/api/sandbox/**",
+            "/api/auth/**",
+            "/api/mock/**",
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/webjars/**",
+            "/actuator/**",
+            "/oauth2/**",
+            "/login/oauth2/**",
+            "/.well-known/**"
+    );
+
+    private final SandboxService sandboxService;
+    private final ObjectMapper objectMapper;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    // =========================================================================
+    // Filter entry point
+    // =========================================================================
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        // Non-guest callers (real users, API keys, unauthenticated) pass through
+        if (!isGuestAuthentication(auth)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // Guest user — sandbox session must be present and valid
+        Optional<String> tokenOpt = extractSandboxToken(request);
+
+        if (tokenOpt.isEmpty()) {
+            log.warn("GUEST request with missing sandbox_token cookie: uri={}",
+                    request.getRequestURI());
+            sendExpiredResponse(request, response);
+            return;
+        }
+
+        String sandboxToken = tokenOpt.get();
+        Optional<SandboxSession> sessionOpt = sandboxService.getSession(sandboxToken);
+
+        if (sessionOpt.isEmpty()) {
+            log.info("Sandbox session not found (expired or invalid): uri={}",
+                    request.getRequestURI());
+            sendExpiredResponse(request, response);
+            return;
+        }
+
+        SandboxSession session = sessionOpt.get();
+
+        if (session.isHardExpired()) {
+            log.info("Sandbox hard cap exceeded: userId={}, uri={}",
+                    session.getUserId(), request.getRequestURI());
+            sendExpiredResponse(request, response);
+            return;
+        }
+
+        // Session is valid — roll the TTL and let the request through
+        sandboxService.rollTtl(sandboxToken, session);
+
+        log.debug("Sandbox session validated: userId={}, remainingMs={}",
+                session.getUserId(), session.remainingMs());
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        return SKIP_PATH_PATTERNS.stream()
+                .anyMatch(pattern -> pathMatcher.match(pattern, path));
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    /**
+     * Returns true only when the current principal carries {@code ROLE_GUEST}.
+     * API key callers carry {@code ROLE_API_KEY}, real users carry {@code ROLE_USER}
+     * or {@code ROLE_ADMIN} — none of those should be intercepted here.
+     */
+    private boolean isGuestAuthentication(Authentication auth) {
+        if (auth == null || !auth.isAuthenticated()) {
+            return false;
+        }
+        return auth.getAuthorities().stream()
+                .anyMatch(a -> "ROLE_GUEST".equals(a.getAuthority()));
+    }
+
+    private Optional<String> extractSandboxToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(cookies)
+                .filter(c -> SANDBOX_COOKIE_NAME.equals(c.getName()))
+                .map(Cookie::getValue)
+                .filter(v -> v != null && !v.isBlank())
+                .findFirst();
+    }
+
+    private void sendExpiredResponse(
+            HttpServletRequest request,
+            HttpServletResponse response) throws IOException {
+
+        ErrorResponse body = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.GONE.value())
+                .error("Sandbox Expired")
+                .message(EXPIRED_MESSAGE)
+                .path(request.getRequestURI())
+                .errorCode(EXPIRED_ERROR_CODE)
+                .actionUrl(CONVERT_URL)
+                .build();
+
+        response.setStatus(HttpStatus.GONE.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/mockify/backend/service/SandboxService.java
+++ b/src/main/java/com/mockify/backend/service/SandboxService.java
@@ -1,0 +1,62 @@
+package com.mockify.backend.service;
+
+import com.mockify.backend.dto.response.auth.AuthResult;
+import com.mockify.backend.dto.response.sandbox.SandboxCreationResult;
+import com.mockify.backend.dto.response.sandbox.SandboxResumeResult;
+import com.mockify.backend.sandbox.SandboxSession;
+
+import java.util.Optional;
+
+public interface SandboxService {
+
+    /**
+     * Creates a fully provisioned sandbox workspace for a new guest user.
+     * Provisions: guest user → org → project → 2 schemas → seeded records.
+     * Stores session in Redis and hashes token in DB as fallback.
+     *
+     * @param clientIp used for logging and potential abuse detection
+     */
+    SandboxCreationResult createSandbox(String clientIp);
+
+    /**
+     * Validates a sandbox token and issues a fresh JWT.
+     * Rolls the Redis TTL forward (up to the hard cap).
+     * Called when the short-lived JWT expires but the session is still valid.
+     *
+     * @throws com.mockify.backend.exception.SandboxExpiredException if hard cap exceeded
+     * @throws com.mockify.backend.exception.ResourceNotFoundException if token unknown
+     */
+    SandboxResumeResult resumeSandbox(String sandboxToken);
+
+    /**
+     * Starts the email-based conversion flow.
+     * Validates the sandbox token, checks email availability,
+     * stores a PendingConversion in Redis, and sends a verification email.
+     *
+     * @throws com.mockify.backend.exception.SandboxExpiredException if session expired
+     * @throws com.mockify.backend.exception.DuplicateResourceException if email taken
+     */
+    void initiateSandboxConversion(String sandboxToken, String email, String password);
+
+    /**
+     * Completes conversion by consuming the email verification token.
+     * In a single transaction: upgrades the guest user to a real account
+     * and promotes the sandbox org to a permanent org.
+     * Invalidates the sandbox session in Redis.
+     *
+     * @return a full auth session (access token + refresh cookie) ready to return
+     */
+    AuthResult completeSandboxConversion(String verificationToken);
+
+    /**
+     * Retrieves the session object for a given sandbox token.
+     * Used by the request interceptor to validate and roll TTL.
+     */
+    Optional<SandboxSession> getSession(String sandboxToken);
+
+    /**
+     * Rolls the session TTL forward.
+     * Caps at hardExpiresAt — no extension beyond the absolute limit.
+     */
+    void rollTtl(String sandboxToken, SandboxSession session);
+}

--- a/src/main/java/com/mockify/backend/service/impl/AdminServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/AdminServiceImpl.java
@@ -42,36 +42,43 @@ public class AdminServiceImpl implements AdminService {
 
     @Override
     public Page<AdminUserResponse> listUsers(String email, UserRole role, Pageable pageable) {
-
-        // Validate page size, protect from abuse
         PageableValidator.validate(pageable);
 
-        // List all users info
+        // Always exclude GUEST accounts from admin user management.
+        // Guests are ephemeral infrastructure; admins should see real accounts only.
+        // The sandbox cleanup scheduler handles guest lifecycle separately.
+        final UserRole excludedRole = UserRole.GUEST;
+
         if (email != null && role != null) {
+            // Specific email + specific role (must not be GUEST to return results)
+            if (role == UserRole.GUEST) {
+                return Page.empty(pageable);
+            }
             return userRepository
                     .findByEmailContainingIgnoreCaseAndRole(email, role, pageable)
                     .map(userMapper::toResponse);
         }
 
-        // Specific user via email
         if (email != null) {
             return userRepository
-                    .findByEmailContainingIgnoreCase(email, pageable)
+                    .findByEmailContainingIgnoreCaseAndRoleNot(email, excludedRole, pageable)
                     .map(userMapper::toResponse);
         }
 
-        // List user with role
         if (role != null) {
+            if (role == UserRole.GUEST) {
+                return Page.empty(pageable);
+            }
             return userRepository
                     .findByRole(role, pageable)
                     .map(userMapper::toResponse);
         }
 
-        log.debug("Admin fetching users details page={}, size={}",
-                pageable.getPageNumber(),
-                pageable.getPageSize());
+        log.debug("Admin fetching users page={}, size={}",
+                pageable.getPageNumber(), pageable.getPageSize());
 
-        return userRepository.findAll(pageable)
+        return userRepository
+                .findByRoleNot(excludedRole, pageable)
                 .map(userMapper::toResponse);
     }
 

--- a/src/main/java/com/mockify/backend/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/AuthServiceImpl.java
@@ -140,9 +140,17 @@ public class AuthServiceImpl implements AuthService {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new UnauthorizedException("Invalid email"));
 
-        // Check if it's a local user (has password)
+        // Block non-local authentication methods
         if (!AUTH_PROVIDER_LOCAL.equals(user.getProviderName())) {
             throw new UnauthorizedException("This account uses " + user.getProviderName() + " login. Please login with that provider.");
+        }
+
+        // Block guest accounts from using password-based login
+        if (user.isGuest()) {
+            throw new UnauthorizedException(
+                    "Guest sessions cannot use password authentication. " +
+                            "Use your sandbox token to resume your session."
+            );
         }
 
         //  BLOCK unverified users

--- a/src/main/java/com/mockify/backend/service/impl/OrganizationServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/OrganizationServiceImpl.java
@@ -129,13 +129,15 @@ public class OrganizationServiceImpl implements OrganizationService {
         // Validate Page size, protect from abuse
         PageableValidator.validate(pageable, 50);
 
-        Page<Organization> organizationsPage = organizationRepository.findByOwnerId(userId, pageable);
+        // isSandbox=false: sandbox orgs are internal infrastructure, not user-visible resources.
+        // A sandbox org that was converted (isSandbox=false) will correctly appear in this list.
+        Page<Organization> organizationsPage =
+                organizationRepository.findByOwnerIdAndIsSandboxFalse(userId, pageable);
 
-        log.debug("User {} fetching Orgs page={}, size={} under user: {}",
+        log.debug("User {} fetching Orgs page={}, size={}",
                 userId,
                 pageable.getPageNumber(),
-                pageable.getPageSize(),
-                userId);
+                pageable.getPageSize());
         return organizationsPage.map(organizationMapper::toResponse);
     }
 

--- a/src/main/java/com/mockify/backend/service/impl/SandboxServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/SandboxServiceImpl.java
@@ -1,0 +1,507 @@
+package com.mockify.backend.service.impl;
+
+import com.mockify.backend.common.enums.UserRole;
+import com.mockify.backend.dto.response.auth.AuthResponse;
+import com.mockify.backend.dto.response.auth.AuthResult;
+import com.mockify.backend.dto.response.sandbox.*;
+import com.mockify.backend.exception.DuplicateResourceException;
+import com.mockify.backend.exception.ResourceNotFoundException;
+import com.mockify.backend.exception.SandboxExpiredException;
+import com.mockify.backend.mapper.UserMapper;
+import com.mockify.backend.model.*;
+import com.mockify.backend.repository.*;
+import com.mockify.backend.sandbox.PendingConversion;
+import com.mockify.backend.sandbox.SandboxSession;
+import com.mockify.backend.sandbox.SandboxSeedDataProvider;
+import com.mockify.backend.security.ApiKeyCryptoService;
+import com.mockify.backend.security.CookieUtil;
+import com.mockify.backend.security.JwtTokenProvider;
+import com.mockify.backend.service.EndpointService;
+import com.mockify.backend.service.MailService;
+import com.mockify.backend.service.SandboxService;
+import com.mockify.backend.service.SlugService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SandboxServiceImpl implements SandboxService {
+
+    // ── Repositories ──────────────────────────────────────────────────────────
+    private final UserRepository userRepository;
+    private final OrganizationRepository organizationRepository;
+    private final ProjectRepository projectRepository;
+    private final MockSchemaRepository mockSchemaRepository;
+    private final MockRecordRepository mockRecordRepository;
+    private final SchemaTemplateRepository schemaTemplateRepository;
+
+    // ── Services & utilities ──────────────────────────────────────────────────
+    private final SlugService slugService;
+    private final EndpointService endpointService;
+    private final MailService mailService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CookieUtil cookieUtil;
+    private final PasswordEncoder passwordEncoder;
+    private final ApiKeyCryptoService cryptoService;
+    private final UserMapper userMapper;
+    private final SandboxSeedDataProvider seedDataProvider;
+
+    // ── Redis ─────────────────────────────────────────────────────────────────
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // ── Config ────────────────────────────────────────────────────────────────
+    @Value("${app.api-key.secret}")
+    private String globalSecret;
+
+    @Value("${app.verification.email.frontend-url}")
+    private String emailVerificationBaseUrl;
+
+    // ── Constants ─────────────────────────────────────────────────────────────
+    static final String SESSION_KEY_PREFIX    = "sandbox:session:";
+    static final String CONVERSION_KEY_PREFIX = "sandbox:convert:";
+    static final String SANDBOX_PROVIDER      = "sandbox";
+    static final String DEFAULT_ORG_NAME      = "My Sandbox";
+    static final String DEFAULT_PROJECT_NAME  = "Demo API";
+    static final Duration ROLLING_TTL         = Duration.ofHours(4);
+    static final Duration HARD_CAP            = Duration.ofHours(24);
+    static final Duration CONVERSION_TTL      = Duration.ofMinutes(15);
+
+    // =========================================================================
+    // CREATE
+    // =========================================================================
+
+    @Override
+    @Transactional
+    public SandboxCreationResult createSandbox(String clientIp) {
+        log.info("Creating sandbox for clientIp={}", clientIp);
+
+        // 1. Provision the workspace hierarchy
+        User guest       = createGuestUser();
+        Organization org = createSandboxOrganization(guest);
+        Project project  = createDemoProject(org);
+
+        // 2. Seed schemas and records
+        List<SandboxSchemaInfo> schemaInfos =
+                seedDefaultData(project, org.getExpiresAt());
+
+        // 3. Generate sandbox token and hash for DB fallback
+        String rawToken   = UUID.randomUUID().toString();
+        String tokenHash  = cryptoService.hashApiKey(rawToken, globalSecret);
+
+        guest.setSandboxTokenHash(tokenHash);
+        guest.setSandboxCreatedAt(LocalDateTime.now());
+        userRepository.save(guest);
+
+        // 4. Store session in Redis
+        SandboxSession session = SandboxSession.builder()
+                .userId(guest.getId())
+                .organizationId(org.getId())
+                .createdAtEpochMs(System.currentTimeMillis())
+                .hardExpiresAtEpochMs(System.currentTimeMillis() + HARD_CAP.toMillis())
+                .build();
+
+        storeSession(rawToken, session, HARD_CAP);
+
+        // 5. Issue guest JWT
+        String jwt = jwtTokenProvider.generateAccessToken(guest.getId(), UserRole.GUEST);
+
+        // 6. Build response
+        ResponseCookie cookie = cookieUtil.createSandboxTokenCookie(rawToken);
+
+        String baseMockUrl = "/api/mock/" + org.getSlug() + "/" + project.getSlug();
+
+        SandboxWorkspace workspace = SandboxWorkspace.builder()
+                .orgSlug(org.getSlug())
+                .projectSlug(project.getSlug())
+                .schemas(schemaInfos)
+                .baseMockUrl(baseMockUrl)
+                .build();
+
+        log.info("Sandbox created: userId={}, orgId={}, schemas={}",
+                guest.getId(), org.getId(), schemaInfos.size());
+
+        return SandboxCreationResult.builder()
+                .accessToken(jwt)
+                .expiresIn(jwtTokenProvider.getAccessTokenExpiration())
+                .sandboxCookie(cookie)
+                .workspace(workspace)
+                .build();
+    }
+
+    // =========================================================================
+    // RESUME
+    // =========================================================================
+
+    @Override
+    public SandboxResumeResult resumeSandbox(String sandboxToken) {
+        SandboxSession session = requireValidSession(sandboxToken);
+
+        // Roll the TTL forward (capped at hard expiry)
+        rollTtl(sandboxToken, session);
+
+        // Issue a fresh JWT for the guest user
+        String jwt = jwtTokenProvider.generateAccessToken(
+                session.getUserId(), UserRole.GUEST);
+
+        log.info("Sandbox session resumed: userId={}", session.getUserId());
+
+        return new SandboxResumeResult(
+                jwt,
+                jwtTokenProvider.getAccessTokenExpiration()
+        );
+    }
+
+    // =========================================================================
+    // CONVERSION — initiate
+    // =========================================================================
+
+    @Override
+    @Transactional(readOnly = true)
+    public void initiateSandboxConversion(
+            String sandboxToken, String email, String password) {
+
+        SandboxSession session = requireValidSession(sandboxToken);
+
+        // Guard: email must be available
+        if (userRepository.existsByEmail(email)) {
+            throw new DuplicateResourceException(
+                    "An account with this email already exists.");
+        }
+
+        // Store pending conversion (email not yet verified)
+        String encodedPassword = passwordEncoder.encode(password);
+
+        PendingConversion pending = PendingConversion.builder()
+                .userId(session.getUserId())
+                .email(email)
+                .encodedPassword(encodedPassword)
+                .sandboxToken(sandboxToken)
+                .build();
+
+        // Unique token for the verification link
+        String conversionToken = UUID.randomUUID().toString();
+        String redisKey = CONVERSION_KEY_PREFIX + conversionToken;
+
+        redisTemplate.opsForValue().set(redisKey, pending, CONVERSION_TTL);
+
+        // Send verification email using the existing mail service
+        String verifyLink = emailVerificationBaseUrl
+                + "/sandbox/verify?token=" + conversionToken;
+
+        mailService.sendEmailVerificationMail(email, verifyLink);
+
+        log.info("Sandbox conversion initiated: userId={}, email={}",
+                session.getUserId(), email);
+    }
+
+    // =========================================================================
+    // CONVERSION — complete
+    // =========================================================================
+
+    @Override
+    @Transactional
+    public AuthResult completeSandboxConversion(String verificationToken) {
+        // 1. Retrieve and consume the pending conversion
+        String redisKey = CONVERSION_KEY_PREFIX + verificationToken;
+        Object raw = redisTemplate.opsForValue().get(redisKey);
+
+        if (raw == null) {
+            throw new ResourceNotFoundException(
+                    "Conversion link is invalid or has expired. " +
+                            "Please request a new conversion link.");
+        }
+
+        PendingConversion pending = (PendingConversion) raw;
+
+        // Consume immediately — single-use token
+        redisTemplate.delete(redisKey);
+
+        // 2. Load the guest user and their sandbox org
+        User guest = userRepository.findById(pending.getUserId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Guest user not found. The sandbox may have already expired."));
+
+        Organization org = organizationRepository
+                .findByOwnerIdAndIsSandboxTrue(guest.getId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Sandbox organization not found."));
+
+        // 3. Promote guest user to real account (atomic with org promotion)
+        guest.setEmail(pending.getEmail());
+        guest.setPassword(pending.getEncodedPassword());
+        guest.setRole(UserRole.USER);
+        guest.setEmailVerified(true);
+        guest.setProviderName("local");
+        guest.setSandboxTokenHash(null);
+        guest.setSandboxCreatedAt(null);
+        userRepository.save(guest);
+
+        // 4. Promote sandbox org to permanent org
+        org.setSandbox(false);
+        org.setExpiresAt(null);
+        organizationRepository.save(org);
+
+        // 5. Invalidate sandbox session in Redis
+        redisTemplate.delete(SESSION_KEY_PREFIX + pending.getSandboxToken());
+
+        log.info("Sandbox conversion completed: userId={}, email={}",
+                guest.getId(), pending.getEmail());
+
+        // 6. Build and return a full auth session
+        return buildAuthResult(guest);
+    }
+
+    // =========================================================================
+    // SESSION HELPERS (used by SandboxRequestInterceptor)
+    // =========================================================================
+
+    @Override
+    public Optional<SandboxSession> getSession(String sandboxToken) {
+        if (sandboxToken == null || sandboxToken.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            Object raw = redisTemplate.opsForValue()
+                    .get(SESSION_KEY_PREFIX + sandboxToken);
+            return Optional.ofNullable((SandboxSession) raw);
+        } catch (Exception e) {
+            log.warn("Redis error reading sandbox session, attempting DB fallback", e);
+            return getSessionFromDb(sandboxToken);
+        }
+    }
+
+    @Override
+    public void rollTtl(String sandboxToken, SandboxSession session) {
+        long now         = System.currentTimeMillis();
+        long hardExpiry  = session.getHardExpiresAtEpochMs();
+        long remaining   = hardExpiry - now;
+
+        if (remaining <= 0) {
+            // Already past hard cap — do not roll
+            return;
+        }
+
+        // Roll forward by ROLLING_TTL but never past hard cap
+        Duration newTtl = Duration.ofMillis(
+                Math.min(ROLLING_TTL.toMillis(), remaining));
+
+        redisTemplate.expire(SESSION_KEY_PREFIX + sandboxToken, newTtl);
+    }
+
+    // =========================================================================
+    // Private helpers — workspace provisioning
+    // =========================================================================
+
+    private User createGuestUser() {
+        User guest = new User();
+        guest.setName("Guest User");
+        guest.setEmail(null);
+        guest.setRole(UserRole.GUEST);
+        guest.setEmailVerified(false);
+        guest.setProviderName(SANDBOX_PROVIDER);
+        // Generate a unique username so the users_username_unique constraint holds
+        guest.setUsername("sandbox_" + UUID.randomUUID().toString().replace("-", "").substring(0, 10));
+        return userRepository.save(guest);
+    }
+
+    private Organization createSandboxOrganization(User owner) {
+        String baseSlug = slugService.generateSlug(DEFAULT_ORG_NAME);
+        String slug = organizationRepository.existsBySlug(baseSlug)
+                ? slugService.generateUniqueSlug(baseSlug)
+                : baseSlug;
+
+        Organization org = new Organization();
+        org.setName(DEFAULT_ORG_NAME);
+        org.setSlug(slug);
+        org.setOwner(owner);
+        org.setSandbox(true);
+        org.setExpiresAt(LocalDateTime.now().plus(HARD_CAP));
+
+        Organization saved = organizationRepository.save(org);
+        endpointService.createEndpoint(saved);
+        return saved;
+    }
+
+    private Project createDemoProject(Organization org) {
+        String slug = slugService.generateSlug(DEFAULT_PROJECT_NAME);
+
+        Project project = new Project();
+        project.setName(DEFAULT_PROJECT_NAME);
+        project.setSlug(slug);
+        project.setOrganization(org);
+
+        Project saved = projectRepository.save(project);
+        endpointService.createEndpoint(saved);
+        return saved;
+    }
+
+    private List<SandboxSchemaInfo> seedDefaultData(
+            Project project, LocalDateTime expiresAt) {
+
+        List<SandboxSchemaInfo> result = new ArrayList<>();
+
+        for (String templateSlug : SandboxSeedDataProvider.DEFAULT_TEMPLATE_SLUGS) {
+            try {
+                Optional<SchemaTemplate> templateOpt =
+                        schemaTemplateRepository.findBySlugAndSystemTemplateTrue(templateSlug);
+
+                if (templateOpt.isEmpty()) {
+                    log.warn("System template '{}' not found in DB — skipping seed", templateSlug);
+                    continue;
+                }
+
+                SchemaTemplate template = templateOpt.get();
+                MockSchema schema = createSchemaFromTemplate(template, project);
+                int seeded = seedRecords(schema, templateSlug, expiresAt);
+
+                result.add(SandboxSchemaInfo.builder()
+                        .schemaId(schema.getId())
+                        .name(schema.getName())
+                        .slug(schema.getSlug())
+                        .apiUrl("/api/mock/" + project.getOrganization().getSlug()
+                                + "/" + project.getSlug() + "/" + schema.getSlug() + "/records")
+                        .seedRecordCount(seeded)
+                        .build());
+
+            } catch (Exception e) {
+                // Seeding is best-effort. Log and continue.
+                // A partially-seeded sandbox is better than a failed creation.
+                log.error("Failed to seed template '{}': {}", templateSlug, e.getMessage(), e);
+            }
+        }
+
+        return result;
+    }
+
+    private MockSchema createSchemaFromTemplate(SchemaTemplate template, Project project) {
+        String baseSlug = slugService.generateSlug(template.getName());
+        String slug = mockSchemaRepository.existsBySlugAndProjectId(baseSlug, project.getId())
+                ? slugService.generateUniqueSlug(baseSlug)
+                : baseSlug;
+
+        MockSchema schema = new MockSchema();
+        schema.setName(template.getName());
+        schema.setSlug(slug);
+        schema.setSchemaJson(new HashMap<>(template.getSchemaJson()));
+        schema.setProject(project);
+
+        MockSchema saved = mockSchemaRepository.save(schema);
+        endpointService.createEndpoint(saved);
+        return saved;
+    }
+
+    private int seedRecords(MockSchema schema, String templateSlug, LocalDateTime expiresAt) {
+        List<Map<String, Object>> seedData = seedDataProvider.getSeedRecords(templateSlug);
+        int count = 0;
+
+        for (Map<String, Object> data : seedData) {
+            MockRecord record = new MockRecord();
+            record.setMockSchema(schema);
+            record.setData(new HashMap<>(data));
+            record.setCreatedAt(LocalDateTime.now());
+            // Records expire with the sandbox org
+            record.setExpiresAt(expiresAt);
+            mockRecordRepository.save(record);
+            count++;
+        }
+
+        return count;
+    }
+
+    // =========================================================================
+    // Private helpers — session management
+    // =========================================================================
+
+    private SandboxSession requireValidSession(String sandboxToken) {
+        SandboxSession session = getSession(sandboxToken)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Sandbox session not found. It may have already expired."));
+
+        if (session.isHardExpired()) {
+            throw new SandboxExpiredException();
+        }
+
+        return session;
+    }
+
+    private void storeSession(String rawToken, SandboxSession session, Duration ttl) {
+        redisTemplate.opsForValue()
+                .set(SESSION_KEY_PREFIX + rawToken, session, ttl);
+    }
+
+    /**
+     * DB fallback: reconstruct a minimal session from the user's stored token hash.
+     * Used when Redis is temporarily unavailable.
+     */
+    private Optional<SandboxSession> getSessionFromDb(String rawToken) {
+        try {
+            String tokenHash = cryptoService.hashApiKey(rawToken, globalSecret);
+            return userRepository.findBySandboxTokenHash(tokenHash)
+                    .map(user -> {
+                        long createdMs = user.getSandboxCreatedAt() != null
+                                ? user.getSandboxCreatedAt()
+                                .atZone(java.time.ZoneId.systemDefault())
+                                .toInstant().toEpochMilli()
+                                : System.currentTimeMillis() - HARD_CAP.toMillis();
+
+                        // Find the sandbox org
+                        List<Organization> orgs =
+                                organizationRepository.findByIsSandboxTrueAndExpiresAtBefore(
+                                        LocalDateTime.now().plusYears(10));
+                        UUID orgId = orgs.stream()
+                                .filter(o -> o.getOwner().getId().equals(user.getId()))
+                                .map(Organization::getId)
+                                .findFirst()
+                                .orElse(null);
+
+                        return SandboxSession.builder()
+                                .userId(user.getId())
+                                .organizationId(orgId)
+                                .createdAtEpochMs(createdMs)
+                                .hardExpiresAtEpochMs(createdMs + HARD_CAP.toMillis())
+                                .build();
+                    });
+        } catch (Exception e) {
+            log.error("DB fallback for sandbox session also failed", e);
+            return Optional.empty();
+        }
+    }
+
+    // =========================================================================
+    // Private helpers — auth session builder
+    // =========================================================================
+
+    /**
+     * Builds a full AuthResult for a newly-converted user.
+     * Duplicates the logic in AuthServiceImpl.login() intentionally —
+     * extracting a shared method would require adding a public API
+     * to AuthService that couples it to SandboxService's needs.
+     * TODO: Refactor into a shared TokenIssuanceService in a future cleanup PR.
+     */
+    private AuthResult buildAuthResult(User user) {
+        String accessToken  = jwtTokenProvider.generateAccessToken(user.getId(), user.getRole());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getId(), user.getRole());
+
+        ResponseCookie refreshCookie = cookieUtil.createRefreshToken(refreshToken);
+
+        AuthResponse response = AuthResponse.builder()
+                .accessToken(accessToken)
+                .tokenType("Bearer")
+                .expiresIn(jwtTokenProvider.getAccessTokenExpiration())
+                .user(userMapper.toResponse(user))
+                .build();
+
+        return new AuthResult(response, refreshCookie);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -33,6 +33,12 @@ app:
       secure: false          # HTTP allowed (localhost)
       same-site: Lax         # Works well for same-site dev
 
+    sandbox-token:
+      name: sandbox_token
+      path: /api/sandbox
+      max-age: 86400       # 24 hours — matches hard cap
+
+
   api-key:
     secret: ${API_KEY_SECRET:your-dev-secret-key-not-for-production-use}
     max-per-organization: 10

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -132,6 +132,17 @@ mockify:
         window: 1m
         type: ip
 
+      # Sandbox provisioning — strict per-IP to prevent resource exhaustion
+      sandbox:
+        paths:
+          - /api/sandbox/start
+          - /api/sandbox/resume
+          - /api/sandbox/convert
+          - /api/sandbox/convert/verify
+        limit: 5
+        window: 1m
+        type: ip
+
       public-mock:
         paths:
           - /api/mock/**

--- a/src/main/resources/db/migration/V13__sandbox_foundation.sql
+++ b/src/main/resources/db/migration/V13__sandbox_foundation.sql
@@ -1,0 +1,45 @@
+-- V13: Sandbox Foundation
+
+-- 1. Drop the existing NOT NULL constraint on email
+ALTER TABLE users
+    ALTER COLUMN email DROP NOT NULL;
+
+-- 2. Drop the blanket unique constraint on email
+--    (created as column-level UNIQUE in V5, Postgres names it users_email_key)
+ALTER TABLE users
+    DROP CONSTRAINT IF EXISTS users_email_key;
+
+-- 3. Create a partial unique index — uniqueness enforced only for real emails
+CREATE UNIQUE INDEX idx_users_email_unique_partial
+    ON users(email)
+    WHERE email IS NOT NULL;
+
+-- 4. Add sandbox lifecycle columns to organizations
+ALTER TABLE organizations
+    ADD COLUMN is_sandbox   BOOLEAN   NOT NULL DEFAULT FALSE,
+    ADD COLUMN expires_at   TIMESTAMP;
+
+-- 5. Enforce the invariant: if is_sandbox=true then expires_at must be set
+ALTER TABLE organizations
+    ADD CONSTRAINT organizations_sandbox_expiry_check
+        CHECK (
+            (is_sandbox = FALSE)
+            OR
+            (is_sandbox = TRUE AND expires_at IS NOT NULL)
+        );
+
+-- 6. Index for the cleanup scheduler query
+CREATE INDEX idx_organizations_sandbox_expiry
+    ON organizations(expires_at)
+    WHERE is_sandbox = TRUE;
+
+-- 7. Add sandbox_token_hash to users for resilience
+--    If Redis is unavailable, we can fall back to DB-stored token.
+--    Stores HMAC-SHA256 hash of the sandboxToken (never the raw token).
+ALTER TABLE users
+    ADD COLUMN sandbox_token_hash VARCHAR(255),
+    ADD COLUMN sandbox_created_at  TIMESTAMP;
+
+CREATE UNIQUE INDEX idx_users_sandbox_token_hash
+    ON users(sandbox_token_hash)
+    WHERE sandbox_token_hash IS NOT NULL;

--- a/src/test/java/com/mockify/backend/sandbox/SanboxSessionTest.java
+++ b/src/test/java/com/mockify/backend/sandbox/SanboxSessionTest.java
@@ -1,0 +1,67 @@
+package com.mockify.backend.sandbox;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SandboxSession domain logic")
+class SandboxSessionTest {
+
+    @Nested
+    @DisplayName("isHardExpired()")
+    class HardExpired {
+
+        @Test
+        @DisplayName("Not expired when hard cap is in the future")
+        void notExpired_whenHardCapInFuture() {
+            SandboxSession session = SandboxSession.builder()
+                    .userId(UUID.randomUUID())
+                    .createdAtEpochMs(System.currentTimeMillis() - 1000)
+                    .hardExpiresAtEpochMs(System.currentTimeMillis() + 60_000)
+                    .build();
+
+            assertThat(session.isHardExpired()).isFalse();
+        }
+
+        @Test
+        @DisplayName("Expired when hard cap is in the past")
+        void expired_whenHardCapInPast() {
+            SandboxSession session = SandboxSession.builder()
+                    .userId(UUID.randomUUID())
+                    .createdAtEpochMs(System.currentTimeMillis() - 90_000)
+                    .hardExpiresAtEpochMs(System.currentTimeMillis() - 1_000)
+                    .build();
+
+            assertThat(session.isHardExpired()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("remainingMs()")
+    class RemainingMs {
+
+        @Test
+        @DisplayName("Returns positive value for active session")
+        void remainingIsPositive_forActiveSession() {
+            SandboxSession session = SandboxSession.builder()
+                    .hardExpiresAtEpochMs(System.currentTimeMillis() + 10_000)
+                    .build();
+
+            assertThat(session.remainingMs()).isGreaterThan(0);
+        }
+
+        @Test
+        @DisplayName("Returns zero (not negative) for expired session")
+        void remainingIsZero_forExpiredSession() {
+            SandboxSession session = SandboxSession.builder()
+                    .hardExpiresAtEpochMs(System.currentTimeMillis() - 5_000)
+                    .build();
+
+            assertThat(session.remainingMs()).isEqualTo(0);
+        }
+    }
+}

--- a/src/test/java/com/mockify/backend/security/SandboxRequestInterceptorTest.java
+++ b/src/test/java/com/mockify/backend/security/SandboxRequestInterceptorTest.java
@@ -1,0 +1,299 @@
+package com.mockify.backend.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mockify.backend.sandbox.SandboxSession;
+import com.mockify.backend.service.SandboxService;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockCookie;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SandboxRequestInterceptor")
+class SandboxRequestInterceptorTest {
+
+    @Mock private SandboxService sandboxService;
+    @Mock private FilterChain filterChain;
+
+    // Use a real ObjectMapper so error response serialisation is verified properly
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .findAndRegisterModules();
+
+    @InjectMocks
+    private SandboxRequestInterceptor interceptor;
+
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private SandboxSession activeSession;
+
+    @BeforeEach
+    void setUp() {
+        request  = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+
+        activeSession = SandboxSession.builder()
+                .userId(UUID.randomUUID())
+                .organizationId(UUID.randomUUID())
+                .createdAtEpochMs(System.currentTimeMillis())
+                .hardExpiresAtEpochMs(System.currentTimeMillis() + 86_400_000L)
+                .build();
+
+        // Set the ObjectMapper via reflection since @InjectMocks won't use our real instance
+        org.springframework.test.util.ReflectionTestUtils.setField(
+                interceptor, "objectMapper", objectMapper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // =========================================================================
+    // Pass-through: non-guest callers
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Pass-through conditions")
+    class PassThrough {
+
+        @Test
+        @DisplayName("No authentication — passes through without Redis lookup")
+        void noAuth_passesThrough() throws Exception {
+            SecurityContextHolder.clearContext();
+            request.setServletPath("/api/organizations");
+
+            interceptor.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            verifyNoInteractions(sandboxService);
+        }
+
+        @Test
+        @DisplayName("ROLE_USER authentication — passes through without Redis lookup")
+        void userAuth_passesThrough() throws Exception {
+            setAuthentication("ROLE_USER");
+            request.setServletPath("/api/organizations");
+
+            interceptor.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            verifyNoInteractions(sandboxService);
+        }
+
+        @Test
+        @DisplayName("ROLE_ADMIN authentication — passes through without Redis lookup")
+        void adminAuth_passesThrough() throws Exception {
+            setAuthentication("ROLE_ADMIN");
+            request.setServletPath("/api/admin/users");
+
+            interceptor.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            verifyNoInteractions(sandboxService);
+        }
+
+        @Test
+        @DisplayName("API key authentication — passes through without Redis lookup")
+        void apiKeyAuth_passesThrough() throws Exception {
+            setAuthentication("ROLE_API_KEY");
+            request.setServletPath("/api/my-org/my-project/schema/records");
+
+            interceptor.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            verifyNoInteractions(sandboxService);
+        }
+    }
+
+    // =========================================================================
+    // shouldNotFilter — sandbox and public paths skipped
+    // =========================================================================
+
+    @Nested
+    @DisplayName("shouldNotFilter()")
+    class ShouldNotFilter {
+
+        @Test
+        @DisplayName("Skips /api/sandbox/** paths")
+        void skips_sandboxPaths() {
+            request.setServletPath("/api/sandbox/start");
+            assertThat(interceptor.shouldNotFilter(request)).isTrue();
+
+            request.setServletPath("/api/sandbox/resume");
+            assertThat(interceptor.shouldNotFilter(request)).isTrue();
+
+            request.setServletPath("/api/sandbox/convert");
+            assertThat(interceptor.shouldNotFilter(request)).isTrue();
+        }
+
+        @Test
+        @DisplayName("Skips /api/auth/** paths")
+        void skips_authPaths() {
+            request.setServletPath("/api/auth/login");
+            assertThat(interceptor.shouldNotFilter(request)).isTrue();
+        }
+
+        @Test
+        @DisplayName("Skips /api/mock/** paths")
+        void skips_publicMockPaths() {
+            request.setServletPath("/api/mock/org/project/schema/records");
+            assertThat(interceptor.shouldNotFilter(request)).isTrue();
+        }
+
+        @Test
+        @DisplayName("Does NOT skip regular API paths")
+        void doesNotSkip_regularApiPaths() {
+            request.setServletPath("/api/organizations");
+            assertThat(interceptor.shouldNotFilter(request)).isFalse();
+
+            request.setServletPath("/api/my-org/my-project/schemas");
+            assertThat(interceptor.shouldNotFilter(request)).isFalse();
+        }
+    }
+
+    // =========================================================================
+    // GUEST user — sandbox token validation
+    // =========================================================================
+
+    @Nested
+    @DisplayName("GUEST user validation")
+    class GuestValidation {
+
+        @BeforeEach
+        void setGuestAuth() {
+            setAuthentication("ROLE_GUEST");
+            request.setServletPath("/api/organizations");
+            request.setRequestURI("/api/organizations");
+        }
+
+        @Test
+        @DisplayName("Missing sandbox_token cookie returns HTTP 410 with SANDBOX_EXPIRED")
+        void missingCookie_returnsSandboxExpired() throws Exception {
+            // No cookies added to request
+
+            interceptor.doFilterInternal(request, response, filterChain);
+
+            assertThat(response.getStatus()).isEqualTo(410);
+            assertThat(response.getContentType()).contains("application/json");
+
+            String body = response.getContentAsString();
+            assertThat(body).contains("SANDBOX_EXPIRED");
+            assertThat(body).contains("/api/sandbox/convert");
+
+            verify(filterChain, never()).doFilter(any(), any());
+            verifyNoInteractions(sandboxService);
+        }
+
+        @Test
+        @DisplayName("Unknown sandbox token (Redis miss) returns HTTP 410")
+        void unknownToken_returnsSandboxExpired() throws Exception {
+            addSandboxCookie("unknown-token-not-in-redis");
+            when(sandboxService.getSession("unknown-token-not-in-redis"))
+                    .thenReturn(Optional.empty());
+
+            interceptor.doFilterInternal(request, response, filterChain);
+
+            assertThat(response.getStatus()).isEqualTo(410);
+            assertThat(response.getContentAsString()).contains("SANDBOX_EXPIRED");
+            verify(filterChain, never()).doFilter(any(), any());
+        }
+
+        @Test
+        @DisplayName("Hard-expired session returns HTTP 410")
+        void hardExpiredSession_returnsSandboxExpired() throws Exception {
+            addSandboxCookie("expired-token");
+
+            SandboxSession expiredSession = SandboxSession.builder()
+                    .userId(UUID.randomUUID())
+                    .createdAtEpochMs(System.currentTimeMillis() - 90_000_000L)
+                    .hardExpiresAtEpochMs(System.currentTimeMillis() - 1_000L)
+                    .build();
+
+            when(sandboxService.getSession("expired-token"))
+                    .thenReturn(Optional.of(expiredSession));
+
+            interceptor.doFilterInternal(request, response, filterChain);
+
+            assertThat(response.getStatus()).isEqualTo(410);
+            verify(filterChain, never()).doFilter(any(), any());
+            verify(sandboxService, never()).rollTtl(anyString(), any());
+        }
+
+        @Test
+        @DisplayName("Valid session passes through and rolls TTL")
+        void validSession_passesThroughAndRollsTtl() throws Exception {
+            addSandboxCookie("valid-token");
+            when(sandboxService.getSession("valid-token"))
+                    .thenReturn(Optional.of(activeSession));
+
+            interceptor.doFilterInternal(request, response, filterChain);
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            verify(filterChain).doFilter(request, response);
+            verify(sandboxService).rollTtl("valid-token", activeSession);
+        }
+
+        @Test
+        @DisplayName("Valid session does not modify the response body")
+        void validSession_doesNotWriteBody() throws Exception {
+            addSandboxCookie("valid-token");
+            when(sandboxService.getSession("valid-token"))
+                    .thenReturn(Optional.of(activeSession));
+
+            interceptor.doFilterInternal(request, response, filterChain);
+
+            assertThat(response.getContentAsString()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Error response contains correct JSON fields")
+        void expiredResponse_hasCorrectJsonStructure() throws Exception {
+            addSandboxCookie("expired-token");
+            when(sandboxService.getSession("expired-token"))
+                    .thenReturn(Optional.empty());
+            request.setServletPath("/api/organizations");
+
+            interceptor.doFilterInternal(request, response, filterChain);
+
+            String json = response.getContentAsString();
+            assertThat(json)
+                    .contains("\"status\":410")
+                    .contains("\"errorCode\":\"SANDBOX_EXPIRED\"")
+                    .contains("\"actionUrl\":\"/api/sandbox/convert\"")
+                    .contains("\"path\":\"/api/organizations\"");
+        }
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private void setAuthentication(String role) {
+        var principal = new User("test-user", "", List.of(new SimpleGrantedAuthority(role)));
+        var auth = new UsernamePasswordAuthenticationToken(
+                principal, null, principal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    private void addSandboxCookie(String value) {
+        request.setCookies(new MockCookie(SandboxRequestInterceptor.SANDBOX_COOKIE_NAME, value));
+    }
+}

--- a/src/test/java/com/mockify/backend/service/impl/SandboxServiceImplTest.java
+++ b/src/test/java/com/mockify/backend/service/impl/SandboxServiceImplTest.java
@@ -1,0 +1,420 @@
+package com.mockify.backend.service.impl;
+
+import com.mockify.backend.common.enums.UserRole;
+import com.mockify.backend.dto.response.sandbox.SandboxCreationResult;
+import com.mockify.backend.dto.response.sandbox.SandboxResumeResult;
+import com.mockify.backend.exception.DuplicateResourceException;
+import com.mockify.backend.exception.ResourceNotFoundException;
+import com.mockify.backend.exception.SandboxExpiredException;
+import com.mockify.backend.mapper.UserMapper;
+import com.mockify.backend.model.*;
+import com.mockify.backend.repository.*;
+import com.mockify.backend.sandbox.PendingConversion;
+import com.mockify.backend.sandbox.SandboxSeedDataProvider;
+import com.mockify.backend.sandbox.SandboxSession;
+import com.mockify.backend.security.ApiKeyCryptoService;
+import com.mockify.backend.security.CookieUtil;
+import com.mockify.backend.security.JwtTokenProvider;
+import com.mockify.backend.service.EndpointService;
+import com.mockify.backend.service.MailService;
+import com.mockify.backend.service.SlugService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SandboxServiceImpl")
+class SandboxServiceImplTest {
+
+    // ── Mocks ─────────────────────────────────────────────────────────────────
+    @Mock private UserRepository userRepository;
+    @Mock private OrganizationRepository organizationRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private MockSchemaRepository mockSchemaRepository;
+    @Mock private MockRecordRepository mockRecordRepository;
+    @Mock private SchemaTemplateRepository schemaTemplateRepository;
+    @Mock private SlugService slugService;
+    @Mock private EndpointService endpointService;
+    @Mock private MailService mailService;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private CookieUtil cookieUtil;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private ApiKeyCryptoService cryptoService;
+    @Mock private UserMapper userMapper;
+    @Mock private SandboxSeedDataProvider seedDataProvider;
+    @Mock private RedisTemplate<String, Object> redisTemplate;
+    @Mock private ValueOperations<String, Object> valueOps;
+
+    @InjectMocks
+    private SandboxServiceImpl sandboxService;
+
+    // ── Fixtures ──────────────────────────────────────────────────────────────
+    private User guestUser;
+    private Organization sandboxOrg;
+    private Project demoProject;
+    private SandboxSession activeSession;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(sandboxService, "globalSecret", "test-secret-min-32-chars-long!!!!");
+        ReflectionTestUtils.setField(sandboxService, "emailVerificationBaseUrl", "http://localhost:3000/verify-email");
+
+        guestUser = new User();
+        guestUser.setId(UUID.randomUUID());
+        guestUser.setRole(UserRole.GUEST);
+        guestUser.setProviderName("sandbox");
+        guestUser.setUsername("sandbox_testuser");
+
+        sandboxOrg = new Organization();
+        sandboxOrg.setId(UUID.randomUUID());
+        sandboxOrg.setName("My Sandbox");
+        sandboxOrg.setSlug("my-sandbox");
+        sandboxOrg.setSandbox(true);
+        sandboxOrg.setExpiresAt(LocalDateTime.now().plusHours(24));
+        sandboxOrg.setOwner(guestUser);
+
+        demoProject = new Project();
+        demoProject.setId(UUID.randomUUID());
+        demoProject.setName("Demo API");
+        demoProject.setSlug("demo-api");
+        demoProject.setOrganization(sandboxOrg);
+
+        activeSession = SandboxSession.builder()
+                .userId(guestUser.getId())
+                .organizationId(sandboxOrg.getId())
+                .createdAtEpochMs(System.currentTimeMillis())
+                .hardExpiresAtEpochMs(System.currentTimeMillis() + Duration.ofHours(24).toMillis())
+                .build();
+    }
+
+    // =========================================================================
+    // createSandbox
+    // =========================================================================
+
+    @Nested
+    @DisplayName("createSandbox()")
+    class CreateSandbox {
+
+        @BeforeEach
+        void setUpCreateSandboxMocks() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOps);
+            when(slugService.generateSlug("My Sandbox")).thenReturn("my-sandbox");
+            when(slugService.generateSlug("Demo API")).thenReturn("demo-api");
+            when(organizationRepository.existsBySlug("my-sandbox")).thenReturn(false);
+            when(userRepository.save(any(User.class))).thenReturn(guestUser);
+            when(organizationRepository.save(any(Organization.class))).thenReturn(sandboxOrg);
+            when(projectRepository.save(any(Project.class))).thenReturn(demoProject);
+            when(cryptoService.hashApiKey(anyString(), anyString())).thenReturn("hashed-token");
+            when(jwtTokenProvider.generateAccessToken(any(), eq(UserRole.GUEST)))
+                    .thenReturn("guest.jwt.token");
+            when(jwtTokenProvider.getAccessTokenExpiration()).thenReturn(3600000L);
+            when(cookieUtil.createSandboxTokenCookie(anyString()))
+                    .thenReturn(ResponseCookie.from("sandbox_token", "token").build());
+            // No templates found — seeding skipped (tested separately)
+            when(schemaTemplateRepository.findBySlugAndSystemTemplateTrue(anyString()))
+                    .thenReturn(Optional.empty());
+        }
+
+        @Test
+        @DisplayName("Returns a valid SandboxCreationResult with JWT and cookie")
+        void createSandbox_returnsValidResult() {
+            SandboxCreationResult result = sandboxService.createSandbox("127.0.0.1");
+
+            assertThat(result).isNotNull();
+            assertThat(result.getAccessToken()).isEqualTo("guest.jwt.token");
+            assertThat(result.getExpiresIn()).isEqualTo(3600000L);
+            assertThat(result.getSandboxCookie()).isNotNull();
+            assertThat(result.getWorkspace()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Creates a guest user with GUEST role and null email")
+        void createSandbox_createsGuestUser() {
+            sandboxService.createSandbox("127.0.0.1");
+
+            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+            // First save is the initial guest user creation
+            verify(userRepository, atLeast(1)).save(userCaptor.capture());
+
+            User savedUser = userCaptor.getAllValues().get(0);
+            assertThat(savedUser.getRole()).isEqualTo(UserRole.GUEST);
+            assertThat(savedUser.getEmail()).isNull();
+            assertThat(savedUser.getProviderName()).isEqualTo("sandbox");
+        }
+
+        @Test
+        @DisplayName("Creates sandbox organization with is_sandbox=true and expires_at set")
+        void createSandbox_createsSandboxOrg() {
+            sandboxService.createSandbox("127.0.0.1");
+
+            ArgumentCaptor<Organization> orgCaptor =
+                    ArgumentCaptor.forClass(Organization.class);
+            verify(organizationRepository).save(orgCaptor.capture());
+
+            Organization org = orgCaptor.getValue();
+            assertThat(org.isSandbox()).isTrue();
+            assertThat(org.getExpiresAt()).isNotNull();
+            assertThat(org.getExpiresAt()).isAfter(LocalDateTime.now());
+        }
+
+        @Test
+        @DisplayName("Stores session in Redis with hard cap TTL")
+        void createSandbox_storesSessionInRedis() {
+            sandboxService.createSandbox("127.0.0.1");
+
+            verify(valueOps).set(
+                    startsWith(SandboxServiceImpl.SESSION_KEY_PREFIX),
+                    any(SandboxSession.class),
+                    eq(SandboxServiceImpl.HARD_CAP)
+            );
+        }
+
+        @Test
+        @DisplayName("Creates endpoint for org and project")
+        void createSandbox_createsEndpoints() {
+            sandboxService.createSandbox("127.0.0.1");
+
+            verify(endpointService).createEndpoint(any(Organization.class));
+            verify(endpointService).createEndpoint(any(Project.class));
+        }
+
+        @Test
+        @DisplayName("Workspace contains correct slugs")
+        void createSandbox_workspaceHasCorrectSlugs() {
+            SandboxCreationResult result = sandboxService.createSandbox("127.0.0.1");
+
+            assertThat(result.getWorkspace().getOrgSlug()).isEqualTo("my-sandbox");
+            assertThat(result.getWorkspace().getProjectSlug()).isEqualTo("demo-api");
+        }
+
+        @Test
+        @DisplayName("Handles slug collision by generating unique slug")
+        void createSandbox_handlesSlugCollision() {
+            when(organizationRepository.existsBySlug("my-sandbox")).thenReturn(true);
+            when(slugService.generateUniqueSlug("my-sandbox")).thenReturn("my-sandbox-abc12345");
+
+            sandboxService.createSandbox("127.0.0.1");
+
+            verify(slugService).generateUniqueSlug("my-sandbox");
+        }
+    }
+
+    // =========================================================================
+    // resumeSandbox
+    // =========================================================================
+
+    @Nested
+    @DisplayName("resumeSandbox()")
+    class ResumeSandbox {
+        @BeforeEach
+        void setUpRedis() {
+            // resumeSandbox() → requireValidSession() → getSession() → opsForValue().get()
+            when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        }
+
+        @Test
+        @DisplayName("Returns new JWT for valid, non-expired token")
+        void resumeSandbox_validToken_returnsNewJwt() {
+            when(valueOps.get(SESSION_KEY("valid-token"))).thenReturn(activeSession);
+            when(jwtTokenProvider.generateAccessToken(guestUser.getId(), UserRole.GUEST))
+                    .thenReturn("new.guest.jwt");
+            when(jwtTokenProvider.getAccessTokenExpiration()).thenReturn(3600000L);
+
+            SandboxResumeResult result = sandboxService.resumeSandbox("valid-token");
+
+            assertThat(result.getAccessToken()).isEqualTo("new.guest.jwt");
+            assertThat(result.getExpiresIn()).isEqualTo(3600000L);
+        }
+
+        @Test
+        @DisplayName("Throws SandboxExpiredException when hard cap is exceeded")
+        void resumeSandbox_expiredSession_throws() {
+            SandboxSession expiredSession = SandboxSession.builder()
+                    .userId(guestUser.getId())
+                    .createdAtEpochMs(System.currentTimeMillis() - 90_000_000L)
+                    .hardExpiresAtEpochMs(System.currentTimeMillis() - 1_000L) // past
+                    .build();
+
+            when(valueOps.get(SESSION_KEY("expired-token"))).thenReturn(expiredSession);
+
+            assertThatThrownBy(() -> sandboxService.resumeSandbox("expired-token"))
+                    .isInstanceOf(SandboxExpiredException.class);
+        }
+
+        @Test
+        @DisplayName("Throws ResourceNotFoundException when token is unknown")
+        void resumeSandbox_unknownToken_throws() {
+            when(valueOps.get(anyString())).thenReturn(null);
+
+            assertThatThrownBy(() -> sandboxService.resumeSandbox("unknown-token"))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("Rolls TTL on valid resume")
+        void resumeSandbox_rollsTtl() {
+            when(valueOps.get(SESSION_KEY("valid-token"))).thenReturn(activeSession);
+            when(jwtTokenProvider.generateAccessToken(any(), any())).thenReturn("jwt");
+            when(jwtTokenProvider.getAccessTokenExpiration()).thenReturn(3600000L);
+
+            sandboxService.resumeSandbox("valid-token");
+
+            verify(redisTemplate).expire(eq(SESSION_KEY("valid-token")), any());
+        }
+    }
+
+    // =========================================================================
+    // initiateSandboxConversion
+    // =========================================================================
+
+    @Nested
+    @DisplayName("initiateSandboxConversion()")
+    class InitiateConversion {
+        @BeforeEach
+        void setUpRedis() {
+            // initiateSandboxConversion() calls getSession() AND stores PendingConversion
+            // — both paths call opsForValue()
+            when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        }
+
+        @Test
+        @DisplayName("Sends verification email and stores PendingConversion in Redis")
+        void initiateConversion_validData_sendsEmailAndStoresInRedis() {
+            when(valueOps.get(SESSION_KEY("valid-token"))).thenReturn(activeSession);
+            when(userRepository.existsByEmail("new@example.com")).thenReturn(false);
+            when(passwordEncoder.encode("password123")).thenReturn("encoded-password");
+
+            sandboxService.initiateSandboxConversion("valid-token", "new@example.com", "password123");
+
+            verify(valueOps).set(
+                    startsWith(SandboxServiceImpl.CONVERSION_KEY_PREFIX),
+                    any(PendingConversion.class),
+                    eq(SandboxServiceImpl.CONVERSION_TTL)
+            );
+            verify(mailService).sendEmailVerificationMail(eq("new@example.com"), anyString());
+        }
+
+        @Test
+        @DisplayName("Throws DuplicateResourceException when email is already registered")
+        void initiateConversion_emailTaken_throws() {
+            when(valueOps.get(SESSION_KEY("valid-token"))).thenReturn(activeSession);
+            when(userRepository.existsByEmail("taken@example.com")).thenReturn(true);
+
+            assertThatThrownBy(() ->
+                    sandboxService.initiateSandboxConversion(
+                            "valid-token", "taken@example.com", "pass"))
+                    .isInstanceOf(DuplicateResourceException.class)
+                    .hasMessageContaining("already exists");
+        }
+
+        @Test
+        @DisplayName("Throws SandboxExpiredException for expired session")
+        void initiateConversion_expiredSession_throws() {
+            SandboxSession expired = SandboxSession.builder()
+                    .userId(guestUser.getId())
+                    .hardExpiresAtEpochMs(System.currentTimeMillis() - 1000)
+                    .build();
+
+            when(valueOps.get(SESSION_KEY("expired"))).thenReturn(expired);
+
+            assertThatThrownBy(() ->
+                    sandboxService.initiateSandboxConversion(
+                            "expired", "test@example.com", "pass"))
+                    .isInstanceOf(SandboxExpiredException.class);
+        }
+
+        @Test
+        @DisplayName("Never sends email if any pre-condition fails")
+        void initiateConversion_failedPrecondition_doesNotSendEmail() {
+            when(valueOps.get(anyString())).thenReturn(null); // token not found
+
+            assertThatThrownBy(() ->
+                    sandboxService.initiateSandboxConversion(
+                            "bad", "test@example.com", "pass"))
+                    .isInstanceOf(ResourceNotFoundException.class);
+
+            verifyNoInteractions(mailService);
+        }
+    }
+
+    // =========================================================================
+    // getSession / rollTtl
+    // =========================================================================
+
+    @Nested
+    @DisplayName("getSession() and rollTtl()")
+    class SessionManagement {
+
+        @Test
+        @DisplayName("getSession returns empty Optional for null token")
+        void getSession_nullToken_returnsEmpty() {
+            assertThat(sandboxService.getSession(null)).isEmpty();
+            assertThat(sandboxService.getSession("")).isEmpty();
+        }
+
+        @Test
+        @DisplayName("getSession returns present Optional for known token")
+        void getSession_knownToken_returnsSession() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOps);
+            when(valueOps.get(SESSION_KEY("known"))).thenReturn(activeSession);
+
+            Optional<SandboxSession> result = sandboxService.getSession("known");
+
+            assertThat(result).isPresent();
+            assertThat(result.get().getUserId()).isEqualTo(guestUser.getId());
+        }
+
+        @Test
+        @DisplayName("rollTtl does not extend beyond hard cap")
+        void rollTtl_doesNotExceedHardCap() {
+            // Session expires in 30 seconds (less than ROLLING_TTL of 4 hours)
+            SandboxSession almostExpired = SandboxSession.builder()
+                    .userId(guestUser.getId())
+                    .hardExpiresAtEpochMs(System.currentTimeMillis() + 30_000)
+                    .build();
+
+            sandboxService.rollTtl("some-token", almostExpired);
+
+            // Should expire in ~30s, not 4 hours
+            ArgumentCaptor<java.time.Duration> durationCaptor =
+                    ArgumentCaptor.forClass(java.time.Duration.class);
+            verify(redisTemplate).expire(anyString(), durationCaptor.capture());
+
+            assertThat(durationCaptor.getValue().getSeconds()).isLessThanOrEqualTo(30);
+        }
+
+        @Test
+        @DisplayName("rollTtl skips extension for hard-expired session")
+        void rollTtl_alreadyExpired_doesNothing() {
+            SandboxSession expired = SandboxSession.builder()
+                    .hardExpiresAtEpochMs(System.currentTimeMillis() - 1000)
+                    .build();
+
+            sandboxService.rollTtl("token", expired);
+
+            verifyNoInteractions(redisTemplate);
+        }
+    }
+
+    // =========================================================================
+    // Helper
+    // =========================================================================
+
+    private String SESSION_KEY(String token) {
+        return SandboxServiceImpl.SESSION_KEY_PREFIX + token;
+    }
+}


### PR DESCRIPTION
## feat(sandbox): foundation, core service & request interceptor

### Summary

This PR lays the complete backend foundation for the sandbox feature:
**"Try Mockify in 30 seconds — no account required."**

A visitor clicks "Try It Now", gets a fully provisioned workspace
(org → project → pre-seeded schemas → realistic records), interacts
with the real product, and optionally converts to a permanent account
with one email verification. No changes to any existing user-facing
endpoint. No existing behavior is modified.

The feature is **not yet user-visible** — the `SandboxController` 
(routes + integration tests) is being opened as a follow-up PR. 
Everything here is independently mergeable and safe to ship.

---

### What changed

#### Database foundation & domain model

**Migration V13** (`V13__sandbox_foundation.sql`)
- `users.email` made nullable to support guest users
- Blanket `UNIQUE` constraint on `email` dropped; replaced with a
  partial unique index (`WHERE email IS NOT NULL`) — two guests with
  `NULL` emails must coexist; two real users with the same email must not
- `organizations.is_sandbox` + `organizations.expires_at` added with a
  DB-level `CHECK` constraint enforcing that sandbox orgs always have
  an expiry date
- Partial index on `organizations(expires_at) WHERE is_sandbox = TRUE`
  for efficient cleanup scheduler queries
- `users.sandbox_token_hash` + `users.sandbox_created_at` added as a
  Redis-fallback for token validation during Redis outages

**Domain changes**
- `UserRole.GUEST` — ephemeral role for sandbox sessions; explicitly
  rejected by `AuthServiceImpl.login()` with a clear error message
- `User.isGuest()` / `User.isRealUser()` role helpers
- `Organization.isSandbox`, `Organization.expiresAt`,
  `Organization.isExpired()` — expiry logic lives on the model,
  not scattered across service methods
- `OrganizationRepository.findByOwnerIdAndIsSandboxTrue()`,
  `findByIsSandboxTrueAndExpiresAtBefore()` for conversion and cleanup
- `UserRepository.findBySandboxTokenHash()`,
  `deleteOrphanedGuestUsers()` for fallback auth and cleanup

---

#### Sandbox core service

**New: `SandboxService` + `SandboxServiceImpl`**

Full sandbox lifecycle in four methods:

| Method | Responsibility |
|---|---|
| `createSandbox(ip)` | Provisions `User → Org → Project → 2 Schemas → Records` in one `@Transactional` call. Stores session in Redis + token hash in DB as fallback. Issues guest JWT. |
| `resumeSandbox(token)` | Validates sandbox token, enforces hard cap, rolls TTL, issues fresh JWT. |
| `initiateSandboxConversion(token, email, password)` | Validates session, checks email availability, stores `PendingConversion` in Redis (15-min TTL), sends verification email. |
| `completeSandboxConversion(verifyToken)` | Atomically promotes guest user → real account and sandbox org → permanent org. Invalidates Redis session. Returns full `AuthResult`. |

**New: `SandboxSeedDataProvider`**  
Realistic hardcoded seed records for `user-profile` and `product-item`
system templates. Best-effort: a seed failure logs and continues rather
than aborting sandbox creation.

**New: `SandboxSession` + `PendingConversion`** (Redis POJOs)  
Uses epoch milliseconds instead of `LocalDateTime` to avoid
`GenericJackson2JsonRedisSerializer`'s lack of `JavaTimeModule`.

**New: `SandboxCreationResult`, `SandboxWorkspace`, `SandboxSchemaInfo`,
`SandboxResumeResult`** (response DTOs)

**Updated: `CookieUtil`**  
`createSandboxTokenCookie()` / `clearSandboxTokenCookie()` — scoped to
`/api/sandbox` path so the cookie is not sent on every API call.

**New: `SandboxExpiredException`** (HTTP 410 Gone)  
410 is semantically correct — the resource existed and is permanently
gone. Distinct from 401 (unauthenticated) and 403 (forbidden), allowing
the frontend to show a targeted "convert your account" prompt.

---

#### Request interceptor, security wiring & correctness fixes

**New: `SandboxRequestInterceptor`** (position 5 in filter chain)

Intercepts every request from a `ROLE_GUEST` principal. Guards that
are checked in order:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added temporary sandbox accounts with automatic expiration and conversion to permanent accounts via email verification
  * Enhanced error responses with machine-readable codes and action URLs for improved frontend handling
  * Implemented session validation and management for guest users

* **Configuration**
  * Added rate limiting (5 requests per minute per IP) for sandbox endpoints
  * Configured sandbox token cookie support

* **Database**
  * Updated schema to support sandbox organizations and guest user tokens

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sadabazhar/mockify-backend/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->