### PR TITLE
Implement OpenAPI Import Feature for Auto-Generating Mock Schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,17 @@
 			<artifactId>javafaker</artifactId>
 			<version>1.0.2</version>
 		</dependency>
+        <!--   Swagger parser    -->
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+            <version>2.1.22</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -162,12 +162,18 @@
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
 
-		<!-- Javafaker-->
-		<dependency>
-			<groupId>com.github.javafaker</groupId>
-			<artifactId>javafaker</artifactId>
-			<version>1.0.2</version>
-		</dependency>
+        <dependency>
+            <groupId>com.github.javafaker</groupId>
+            <artifactId>javafaker</artifactId>
+            <version>1.0.2</version>
+
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <!--   Swagger parser    -->
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>

--- a/src/main/java/com/mockify/backend/controller/OpenApiImportController.java
+++ b/src/main/java/com/mockify/backend/controller/OpenApiImportController.java
@@ -1,0 +1,54 @@
+package com.mockify.backend.controller;
+
+
+import com.mockify.backend.dto.response.imports.OpenApiImportResponse;
+import com.mockify.backend.security.SecurityUtils;
+import com.mockify.backend.service.EndpointService;
+import com.mockify.backend.service.OpenApiImportService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Slf4j
+public class OpenApiImportController {
+
+    private final OpenApiImportService openApiImportService;
+    private final EndpointService endpointService;
+
+    @PostMapping(
+            value = "/{org}/{project}/import/openapi",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<OpenApiImportResponse> importOpenApi(
+            @PathVariable String org,
+            @PathVariable String project,
+            @RequestPart("file") MultipartFile file,
+            Authentication auth
+    ) {
+
+        UUID userId = SecurityUtils.resolveUserId(auth);
+
+        UUID projectId = endpointService.resolveProject(org, project);
+
+        log.info("User {} importing OpenAPI file '{}' into org='{}', project='{}'",
+                userId,
+                file.getOriginalFilename(),
+                org,
+                project
+        );
+
+        OpenApiImportResponse response = openApiImportService.importOpenApi(userId, projectId, file);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/mockify/backend/controller/OpenApiImportController.java
+++ b/src/main/java/com/mockify/backend/controller/OpenApiImportController.java
@@ -1,10 +1,12 @@
 package com.mockify.backend.controller;
 
 
+import com.mockify.backend.dto.request.imports.OpenApiImportRequest;
 import com.mockify.backend.dto.response.imports.OpenApiImportResponse;
 import com.mockify.backend.security.SecurityUtils;
 import com.mockify.backend.service.EndpointService;
 import com.mockify.backend.service.OpenApiImportService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -32,13 +34,14 @@ public class OpenApiImportController {
     public ResponseEntity<OpenApiImportResponse> importOpenApi(
             @PathVariable String org,
             @PathVariable String project,
-            @RequestPart("file") MultipartFile file,
+            @ModelAttribute @Valid OpenApiImportRequest request,
             Authentication auth
     ) {
 
         UUID userId = SecurityUtils.resolveUserId(auth);
-
         UUID projectId = endpointService.resolveProject(org, project);
+
+        MultipartFile file = request.getFile();
 
         log.info("User {} importing OpenAPI file '{}' into org='{}', project='{}'",
                 userId,

--- a/src/main/java/com/mockify/backend/dto/internal/ParsedOpenApiSpec.java
+++ b/src/main/java/com/mockify/backend/dto/internal/ParsedOpenApiSpec.java
@@ -1,0 +1,14 @@
+package com.mockify.backend.dto.internal;
+
+import io.swagger.v3.oas.models.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import java.util.Map;
+
+@AllArgsConstructor
+@Getter @Setter
+public class ParsedOpenApiSpec {
+    private String version;
+    private Map<String, Schema> schemas;
+}

--- a/src/main/java/com/mockify/backend/dto/request/imports/OpenApiImportRequest.java
+++ b/src/main/java/com/mockify/backend/dto/request/imports/OpenApiImportRequest.java
@@ -1,0 +1,11 @@
+package com.mockify.backend.dto.request.imports;
+
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
+
+
+public class OpenApiImportRequest {
+
+    @NotNull(message = "OpenAPI file is required")
+    private MultipartFile file;
+}

--- a/src/main/java/com/mockify/backend/dto/request/imports/OpenApiImportRequest.java
+++ b/src/main/java/com/mockify/backend/dto/request/imports/OpenApiImportRequest.java
@@ -1,9 +1,14 @@
 package com.mockify.backend.dto.request.imports;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
 
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class OpenApiImportRequest {
 
     @NotNull(message = "OpenAPI file is required")

--- a/src/main/java/com/mockify/backend/dto/response/imports/OpenApiImportResponse.java
+++ b/src/main/java/com/mockify/backend/dto/response/imports/OpenApiImportResponse.java
@@ -2,6 +2,8 @@ package com.mockify.backend.dto.response.imports;
 
 import com.mockify.backend.dto.response.schema.MockSchemaResponse;
 import lombok.*;
+
+import java.util.Collections;
 import java.util.List;
 
 @Getter
@@ -17,10 +19,12 @@ public class OpenApiImportResponse {
 
     public static OpenApiImportResponse of(List<MockSchemaResponse> imported, List<SkippedSchema> skipped) {
         OpenApiImportResponse res = new OpenApiImportResponse();
-        res.imported = imported;
-        res.skipped = skipped;
-        res.totalImported = imported.size();
-        res.totalSkipped = skipped.size();
+
+        res.imported = imported == null ? Collections.emptyList() : imported;
+        res.skipped = skipped == null ? Collections.emptyList() : skipped;
+
+        res.totalImported = res.imported.size();
+        res.totalSkipped = res.skipped.size();
         return res;
     }
 }

--- a/src/main/java/com/mockify/backend/dto/response/imports/OpenApiImportResponse.java
+++ b/src/main/java/com/mockify/backend/dto/response/imports/OpenApiImportResponse.java
@@ -4,6 +4,10 @@ import com.mockify.backend.dto.response.schema.MockSchemaResponse;
 import lombok.*;
 import java.util.List;
 
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class OpenApiImportResponse {
 
     private List<MockSchemaResponse> imported;

--- a/src/main/java/com/mockify/backend/dto/response/imports/OpenApiImportResponse.java
+++ b/src/main/java/com/mockify/backend/dto/response/imports/OpenApiImportResponse.java
@@ -1,0 +1,22 @@
+package com.mockify.backend.dto.response.imports;
+
+import com.mockify.backend.dto.response.schema.MockSchemaResponse;
+import lombok.*;
+import java.util.List;
+
+public class OpenApiImportResponse {
+
+    private List<MockSchemaResponse> imported;
+    private List<SkippedSchema> skipped;
+    private int totalImported;
+    private int totalSkipped;
+
+    public static OpenApiImportResponse of(List<MockSchemaResponse> imported, List<SkippedSchema> skipped) {
+        OpenApiImportResponse res = new OpenApiImportResponse();
+        res.imported = imported;
+        res.skipped = skipped;
+        res.totalImported = imported.size();
+        res.totalSkipped = skipped.size();
+        return res;
+    }
+}

--- a/src/main/java/com/mockify/backend/dto/response/imports/SkippedSchema.java
+++ b/src/main/java/com/mockify/backend/dto/response/imports/SkippedSchema.java
@@ -1,0 +1,6 @@
+package com.mockify.backend.dto.response.imports;
+
+public record SkippedSchema(
+        String component,
+        String reason
+) {}

--- a/src/main/java/com/mockify/backend/exception/InvalidOpenApiException.java
+++ b/src/main/java/com/mockify/backend/exception/InvalidOpenApiException.java
@@ -1,0 +1,10 @@
+package com.mockify.backend.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidOpenApiException extends BaseException{
+
+    public InvalidOpenApiException(String message){
+        super(message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/mockify/backend/service/OpenApiImportService.java
+++ b/src/main/java/com/mockify/backend/service/OpenApiImportService.java
@@ -1,0 +1,11 @@
+package com.mockify.backend.service;
+
+import com.mockify.backend.dto.response.imports.OpenApiImportResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+public interface OpenApiImportService {
+
+    public OpenApiImportResponse importOpenApi(UUID userId, UUID projectId, MultipartFile file);
+}

--- a/src/main/java/com/mockify/backend/service/OpenApiParserService.java
+++ b/src/main/java/com/mockify/backend/service/OpenApiParserService.java
@@ -1,0 +1,10 @@
+package com.mockify.backend.service;
+
+import com.mockify.backend.dto.internal.ParsedOpenApiSpec;
+import org.springframework.web.multipart.MultipartFile;
+
+
+public interface OpenApiParserService {
+
+    public ParsedOpenApiSpec parse(MultipartFile file);
+}

--- a/src/main/java/com/mockify/backend/service/OpenApiValidatorService.java
+++ b/src/main/java/com/mockify/backend/service/OpenApiValidatorService.java
@@ -1,0 +1,8 @@
+package com.mockify.backend.service;
+
+import com.mockify.backend.dto.internal.ParsedOpenApiSpec;
+
+public interface OpenApiValidatorService {
+
+    public void validate(ParsedOpenApiSpec spec);
+}

--- a/src/main/java/com/mockify/backend/service/SchemaExtractorService.java
+++ b/src/main/java/com/mockify/backend/service/SchemaExtractorService.java
@@ -1,0 +1,9 @@
+package com.mockify.backend.service;
+
+import io.swagger.v3.oas.models.media.Schema;
+import java.util.Map;
+
+public interface SchemaExtractorService {
+
+    public Map<String, Object> extractSchema(String schemaName, Schema<?> schema);
+}

--- a/src/main/java/com/mockify/backend/service/impl/MockSchemaServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockSchemaServiceImpl.java
@@ -23,9 +23,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -43,7 +43,7 @@ public class MockSchemaServiceImpl implements MockSchemaService {
 
     // Create a new mock schema under a specific project Only
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @PreAuthorize("hasPermission(#projectId, 'PROJECT', 'SCHEMA:WRITE')")
     public MockSchemaResponse createSchema(UUID userId, UUID projectId, CreateMockSchemaRequest request) {
         Project project = projectRepository.findById(projectId)

--- a/src/main/java/com/mockify/backend/service/impl/MockValidatorServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockValidatorServiceImpl.java
@@ -571,15 +571,28 @@ public class MockValidatorServiceImpl implements MockValidatorService {
             Object nestedDef
     ) {
 
-        if (!(nestedDef instanceof String) &&
-                !(nestedDef instanceof Map<?, ?>)) {
-
-            throw new BadRequestException(
-                    "Nested field '" + nestedField +
-                            "' inside '" + parentField +
-                            "' has invalid definition"
-            );
+        if (nestedDef instanceof String nestedType) {
+            parseType(parentField + "." + nestedField, nestedType);
+            return;
         }
+
+        if (nestedDef instanceof Map<?, ?> nestedMap) {
+
+            Map<String, Object> wrapped = new LinkedHashMap<>();
+            wrapped.put(
+                    nestedField,
+                    castToStringObjectMap(nestedMap)
+            );
+
+            validateSchemaDefinition(wrapped);
+            return;
+        }
+
+        throw new BadRequestException(
+                "Nested field '" + nestedField +
+                        "' inside '" + parentField +
+                        "' has invalid definition"
+        );
     }
 
 

--- a/src/main/java/com/mockify/backend/service/impl/MockValidatorServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockValidatorServiceImpl.java
@@ -4,12 +4,10 @@ import com.mockify.backend.exception.BadRequestException;
 import com.mockify.backend.service.MockValidatorService;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.springframework.stereotype.Service;
-
 import java.net.URI;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.*;
-
 
 @Service
 public class MockValidatorServiceImpl implements MockValidatorService {
@@ -150,6 +148,19 @@ public class MockValidatorServiceImpl implements MockValidatorService {
                                         "' must define items"
                         );
                     }
+
+                    if (items instanceof String str) {
+                        parseType(field + ".items", str);
+                    } else if (items instanceof Map<?, ?> map) {
+                        validateSchemaDefinition(
+                                castToStringObjectMap(map)
+                        );
+                    } else {
+                        throw new BadRequestException(
+                                "Array field '" + field +
+                                        "' must define valid type"
+                        );
+                    }
                 }
 
                 /*
@@ -278,6 +289,92 @@ public class MockValidatorServiceImpl implements MockValidatorService {
                             field,
                             "array"
                     );
+
+                    Object itemsDef = defMap.get("items");
+
+                    if (itemsDef == null) {
+                        throw new BadRequestException(
+                                "Array field '" + field + "' must define items"
+                        );
+                    }
+
+                    List<?> list = (List<?>) value;
+
+                    for (int i = 0; i < list.size(); i++) {
+
+                        Object itemValue = list.get(i);
+                        String itemField = field + "[" + i + "]";
+
+                        /*
+                         * Array of primitive types
+                         */
+                        if (itemsDef instanceof String itemTypeStr) {
+
+                            ALLOWED_TYPES itemType =
+                                    parseType(itemField, itemTypeStr);
+
+                            validateValueByType(
+                                    itemField,
+                                    itemType,
+                                    itemValue,
+                                    null
+                            );
+
+                            continue;
+                        }
+
+                        /*
+                         * Array of objects / nested schemas
+                         */
+                        if (itemsDef instanceof Map<?, ?> itemMap) {
+
+                            require(
+                                    itemValue instanceof Map<?, ?>,
+                                    itemField,
+                                    "object"
+                            );
+
+                            Map<String, Object> itemSchema =
+                                    castToStringObjectMap(itemMap);
+
+                            Object itemType = itemSchema.get("type");
+
+                            if (itemType == null) {
+
+                                validateRecordAgainstSchema(
+                                        itemSchema,
+                                        castToStringObjectMap(
+                                                (Map<?, ?>) itemValue
+                                        )
+                                );
+
+                                continue;
+                            }
+
+                            if ("object".equalsIgnoreCase(itemType.toString()) ||
+                                    "json".equalsIgnoreCase(itemType.toString())) {
+
+                                validateRecordAgainstSchema(
+                                        extractNestedSchema(itemSchema),
+                                        castToStringObjectMap(
+                                                (Map<?, ?>) itemValue
+                                        )
+                                );
+
+                                continue;
+                            }
+
+                            throw new BadRequestException(
+                                    "Array field '" + field +
+                                            "' supports only object schemas in items"
+                            );
+                        }
+
+                        throw new BadRequestException(
+                                "Invalid items definition for array field '" +
+                                        field + "'"
+                        );
+                    }
 
                     continue;
                 }
@@ -436,7 +533,14 @@ public class MockValidatorServiceImpl implements MockValidatorService {
                 require(value instanceof String, field, "url");
 
                 try {
-                    new URI(value.toString());
+                    URI uri = new URI(value.toString());
+
+                    if (uri.getScheme() == null ||
+                            uri.getHost() == null) {
+                        throw new BadRequestException(
+                                "Invalid URL format for field '" + field + "'"
+                        );
+                    }
                 } catch (Exception e) {
                     throw new BadRequestException(
                             "Invalid URL format for field '" + field + "'"

--- a/src/main/java/com/mockify/backend/service/impl/MockValidatorServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/MockValidatorServiceImpl.java
@@ -22,7 +22,6 @@ public class MockValidatorServiceImpl implements MockValidatorService {
 
     private enum ALLOWED_TYPES {
 
-
         STRING("string"),
         NUMBER("number"),
         BOOLEAN("boolean"),
@@ -54,8 +53,16 @@ public class MockValidatorServiceImpl implements MockValidatorService {
     }
 
 
-    // validateSchemaDefinition
-
+    /**
+     * SCHEMA VALIDATION
+     *
+     * Supports:
+     * - Primitive fields
+     * - Arrays
+     * - Nested objects
+     * - JSON objects
+     * - Enums
+     */
     @Override
     public void validateSchemaDefinition(Map<String, Object> schemaJson) {
 
@@ -72,35 +79,117 @@ public class MockValidatorServiceImpl implements MockValidatorService {
                 throw new BadRequestException("Schema field name cannot be empty");
             }
 
-            ALLOWED_TYPES type;
-
-
+            /*
+             * SIMPLE TYPE:
+             * "name": "string"
+             */
             if (definition instanceof String strType) {
-                type = parseType(field, strType);
-            } else if (definition instanceof Map<?, ?> defMap) {
+
+                parseType(field, strType);
+                continue;
+            }
+
+            /*
+             * COMPLEX FIELD:
+             * object / array / enum / nested object
+             */
+            if (definition instanceof Map<?, ?> defMap) {
 
                 Object typeObj = defMap.get("type");
-                if (!(typeObj instanceof String)) {
-                    throw new BadRequestException("Field '" + field + "' must define a type");
+
+                /*
+                 * NESTED OBJECT SUPPORT:
+                 *
+                 * Example:
+                 * "profile": {
+                 *    "age": "number",
+                 *    "gender": "string"
+                 * }
+                 *
+                 * No explicit "type" means recursive object
+                 */
+                if (typeObj == null) {
+
+                    validateSchemaDefinition(castToStringObjectMap(defMap));
+                    continue;
                 }
 
-                type = parseType(field, typeObj.toString());
+                if (!(typeObj instanceof String)) {
+                    throw new BadRequestException(
+                            "Field '" + field + "' must define a valid type"
+                    );
+                }
 
+                ALLOWED_TYPES type = parseType(field, typeObj.toString());
+
+                /*
+                 * ENUM validation
+                 */
                 if (type == ALLOWED_TYPES.ENUM) {
+
                     Object values = defMap.get("values");
+
                     if (!(values instanceof List<?> list) || list.isEmpty()) {
-                        throw new BadRequestException("Enum field '" + field + "' must define non-empty values");
+                        throw new BadRequestException(
+                                "Enum field '" + field +
+                                        "' must define non-empty values"
+                        );
                     }
                 }
-            } else {
-                throw new BadRequestException("Invalid schema format for field '" + field + "'");
+
+                /*
+                 * ARRAY validation
+                 */
+                if (type == ALLOWED_TYPES.ARRAY) {
+
+                    Object items = defMap.get("items");
+
+                    if (items == null) {
+                        throw new BadRequestException(
+                                "Array field '" + field +
+                                        "' must define items"
+                        );
+                    }
+                }
+
+                /*
+                 * OBJECT / JSON recursive validation
+                 */
+                if (type == ALLOWED_TYPES.OBJECT ||
+                        type == ALLOWED_TYPES.JSON) {
+
+                    for (Map.Entry<?, ?> nestedEntry : defMap.entrySet()) {
+
+                        String nestedField = nestedEntry.getKey().toString();
+
+                        if ("type".equals(nestedField)) {
+                            continue;
+                        }
+
+                        validateNestedDefinition(
+                                field,
+                                nestedField,
+                                nestedEntry.getValue()
+                        );
+                    }
+                }
+
+                continue;
             }
+
+            throw new BadRequestException(
+                    "Invalid schema format for field '" + field + "'"
+            );
         }
     }
 
 
-    // Record Validation
-
+    /**
+     * RECORD VALIDATION
+     *
+     * Validates user records against schema,
+     * including nested object structures.
+     */
     @Override
     public void validateRecordAgainstSchema(
             Map<String, Object> schemaJson,
@@ -119,67 +208,157 @@ public class MockValidatorServiceImpl implements MockValidatorService {
             Object schemaDef = entry.getValue();
 
             if (!recordJson.containsKey(field)) {
-                throw new BadRequestException("Missing field '" + field + "' in record");
+                throw new BadRequestException(
+                        "Missing field '" + field + "' in record"
+                );
             }
 
             Object value = recordJson.get(field);
 
-            ALLOWED_TYPES type;
-            List<?> enumValues = null;
-
+            /*
+             * SIMPLE TYPE
+             */
             if (schemaDef instanceof String strType) {
-                type = parseType(field, strType);
-            } else if (schemaDef instanceof Map<?, ?> defMap) {
+
+                ALLOWED_TYPES type = parseType(field, strType);
+                validateValueByType(field, type, value, null);
+
+                continue;
+            }
+
+            /*
+             * COMPLEX TYPE
+             */
+            if (schemaDef instanceof Map<?, ?> defMap) {
 
                 Object typeObj = defMap.get("type");
 
+                /*
+                 * NESTED OBJECT
+                 */
                 if (typeObj == null) {
-                    throw new BadRequestException(
-                            "Field '" + field + "' schema must define a 'type' property"
+
+                    require(
+                            value instanceof Map<?, ?>,
+                            field,
+                            "object"
                     );
+
+                    validateRecordAgainstSchema(
+                            castToStringObjectMap(defMap),
+                            castToStringObjectMap((Map<?, ?>) value)
+                    );
+
+                    continue;
                 }
 
                 if (!(typeObj instanceof String)) {
                     throw new BadRequestException(
-                            "Field '" + field + "' schema 'type' must be a string"
+                            "Field '" + field +
+                                    "' schema type must be string"
                     );
                 }
 
-                type = parseType(field, (String) typeObj);
+                ALLOWED_TYPES type =
+                        parseType(field, typeObj.toString());
 
+                List<?> enumValues = null;
 
                 if (type == ALLOWED_TYPES.ENUM) {
                     enumValues = (List<?>) defMap.get("values");
                 }
-            } else {
-                throw new BadRequestException("Invalid schema definition for field '" + field + "'");
+
+                /*
+                 * ARRAY validation
+                 */
+                if (type == ALLOWED_TYPES.ARRAY) {
+
+                    require(
+                            value instanceof List<?>,
+                            field,
+                            "array"
+                    );
+
+                    continue;
+                }
+
+                /*
+                 * OBJECT recursive validation
+                 */
+                if (type == ALLOWED_TYPES.OBJECT ||
+                        type == ALLOWED_TYPES.JSON) {
+
+                    require(
+                            value instanceof Map<?, ?>,
+                            field,
+                            "object"
+                    );
+
+                    Map<String, Object> nestedSchema =
+                            extractNestedSchema(defMap);
+
+                    validateRecordAgainstSchema(
+                            nestedSchema,
+                            castToStringObjectMap((Map<?, ?>) value)
+                    );
+
+                    continue;
+                }
+
+                validateValueByType(
+                        field,
+                        type,
+                        value,
+                        enumValues
+                );
+
+                continue;
             }
 
-            validateValueByType(field, type, value, enumValues);
+            throw new BadRequestException(
+                    "Invalid schema definition for field '" + field + "'"
+            );
         }
 
-        // Extra field protection
+        /*
+         * Extra field protection
+         */
         for (String field : recordJson.keySet()) {
             if (!schemaJson.containsKey(field)) {
-                throw new BadRequestException("Field '" + field + "' is not allowed in this schema");
+                throw new BadRequestException(
+                        "Field '" + field +
+                                "' is not allowed in this schema"
+                );
             }
         }
     }
 
 
-    // validateValueByType
-
-    private void validateValueByType(String field, ALLOWED_TYPES type, Object value, List<?> enumValues) {
+    /**
+     * VALUE TYPE VALIDATION
+     */
+    private void validateValueByType(
+            String field,
+            ALLOWED_TYPES type,
+            Object value,
+            List<?> enumValues
+    ) {
 
         if (type == ALLOWED_TYPES.NULL) {
+
             if (value != null) {
-                throw new BadRequestException("Field '" + field + "' must be null");
+                throw new BadRequestException(
+                        "Field '" + field + "' must be null"
+                );
             }
+
             return;
         }
 
         if (value == null) {
-            throw new BadRequestException("Field '" + field + "' cannot be null");
+            throw new BadRequestException(
+                    "Field '" + field + "' cannot be null"
+            );
         }
 
         switch (type) {
@@ -207,17 +386,23 @@ public class MockValidatorServiceImpl implements MockValidatorService {
 
             case EMAIL:
                 require(value instanceof String, field, "email");
+
                 if (!EmailValidator.getInstance().isValid(value.toString())) {
-                    throw new BadRequestException("Invalid email format for field '" + field + "'");
+                    throw new BadRequestException(
+                            "Invalid email format for field '" + field + "'"
+                    );
                 }
                 break;
 
             case UUID:
                 require(value instanceof String, field, "uuid");
+
                 try {
                     UUID.fromString(value.toString());
                 } catch (Exception e) {
-                    throw new BadRequestException("Invalid UUID format for field '" + field + "'");
+                    throw new BadRequestException(
+                            "Invalid UUID format for field '" + field + "'"
+                    );
                 }
                 break;
 
@@ -237,10 +422,13 @@ public class MockValidatorServiceImpl implements MockValidatorService {
 
             case DATETIME:
                 require(value instanceof String, field, "datetime");
+
                 try {
                     OffsetDateTime.parse(value.toString());
                 } catch (Exception e) {
-                    throw new BadRequestException("Invalid datetime format (ISO-8601) for field '" + field + "'");
+                    throw new BadRequestException(
+                            "Invalid datetime format for field '" + field + "'"
+                    );
                 }
                 break;
 
@@ -251,8 +439,7 @@ public class MockValidatorServiceImpl implements MockValidatorService {
                     new URI(value.toString());
                 } catch (Exception e) {
                     throw new BadRequestException(
-                            "Invalid URL format for field '"
-                                    + field + "'"
+                            "Invalid URL format for field '" + field + "'"
                     );
                 }
                 break;
@@ -260,26 +447,109 @@ public class MockValidatorServiceImpl implements MockValidatorService {
             case ENUM:
                 if (enumValues == null || !enumValues.contains(value)) {
                     throw new BadRequestException(
-                            "Invalid enum value for field '" + field + "'. Allowed: " + enumValues
+                            "Invalid enum value for field '" +
+                                    field +
+                                    "'. Allowed: " +
+                                    enumValues
                     );
                 }
                 break;
         }
     }
 
-    private void require(boolean condition, String field, String type) {
-        if (!condition) {
-            throw new BadRequestException("Field '" + field + "' must be of type " + type);
+
+    /**
+     * Validate nested field definitions recursively
+     */
+    private void validateNestedDefinition(
+            String parentField,
+            String nestedField,
+            Object nestedDef
+    ) {
+
+        if (!(nestedDef instanceof String) &&
+                !(nestedDef instanceof Map<?, ?>)) {
+
+            throw new BadRequestException(
+                    "Nested field '" + nestedField +
+                            "' inside '" + parentField +
+                            "' has invalid definition"
+            );
         }
     }
 
-    // Helper (internal only)
 
-    private ALLOWED_TYPES parseType(String field, String typeStr) {
+    /**
+     * Extract nested schema by removing "type"
+     */
+    private Map<String, Object> extractNestedSchema(
+            Map<?, ?> defMap
+    ) {
+
+        Map<String, Object> nested = new HashMap<>();
+
+        for (Map.Entry<?, ?> entry : defMap.entrySet()) {
+
+            String key = entry.getKey().toString();
+
+            if ("type".equals(key)) {
+                continue;
+            }
+
+            nested.put(key, entry.getValue());
+        }
+
+        return nested;
+    }
+
+
+    /**
+     * Generic safe casting helper
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> castToStringObjectMap(
+            Map<?, ?> map
+    ) {
+
+        return (Map<String, Object>) map;
+    }
+
+
+    /**
+     * Validation helper
+     */
+    private void require(
+            boolean condition,
+            String field,
+            String type
+    ) {
+
+        if (!condition) {
+            throw new BadRequestException(
+                    "Field '" + field +
+                            "' must be of type " + type
+            );
+        }
+    }
+
+
+    /**
+     * Type parser helper
+     */
+    private ALLOWED_TYPES parseType(
+            String field,
+            String typeStr
+    ) {
+
         try {
             return ALLOWED_TYPES.from(typeStr);
-        } catch (IllegalArgumentException e) {
-            throw new BadRequestException("Invalid type for field '" + field + "': " + typeStr);
+        } catch (Exception e) {
+            throw new BadRequestException(
+                    "Invalid type for field '" +
+                            field +
+                            "': " +
+                            typeStr
+            );
         }
     }
 }

--- a/src/main/java/com/mockify/backend/service/impl/OpenApiImportServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/OpenApiImportServiceImpl.java
@@ -1,0 +1,174 @@
+package com.mockify.backend.service.impl;
+
+import com.mockify.backend.dto.internal.ParsedOpenApiSpec;
+import com.mockify.backend.dto.request.schema.CreateMockSchemaRequest;
+import com.mockify.backend.dto.response.imports.OpenApiImportResponse;
+import com.mockify.backend.dto.response.imports.SkippedSchema;
+import com.mockify.backend.dto.response.schema.MockSchemaResponse;
+import com.mockify.backend.exception.ResourceNotFoundException;
+import com.mockify.backend.model.Project;
+import com.mockify.backend.repository.ProjectRepository;
+import com.mockify.backend.service.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import io.swagger.v3.oas.models.media.Schema;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * OpenApiImportService
+ *
+ * Main orchestrator for OpenAPI import flow
+ *
+ * Full flow:
+ * 1. Receive uploaded file
+ * 2. Parse raw OpenAPI
+ * 3. Validate specification
+ * 4. Extract schemas
+ * 5. Convert schemas into Mockify schemaJson
+ * 6. Create actual Mock Schemas inside project
+ * 7. Collect successes + failures
+ * 8. Return final summary
+ *
+ * This service is responsible for business execution only.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OpenApiImportServiceImpl implements OpenApiImportService {
+
+    private final OpenApiParserService parserService;
+    private final OpenApiValidatorService validatorService;
+    private final SchemaExtractorService extractorService;
+
+    private final MockSchemaService mockSchemaService;
+    private final ProjectRepository projectRepository;
+
+    /**
+     * Import OpenAPI file and auto-generate mock schemas
+     *
+     * Security:
+     * User must have schema write permission in project
+     *
+     * @param userId authenticated user
+     * @param projectId target project
+     * @param file uploaded swagger/openapi file
+     * @return import summary
+     */
+    @Transactional
+    @PreAuthorize("hasPermission(#projectId, 'PROJECT', 'SCHEMA:WRITE')")
+    @Override
+    public OpenApiImportResponse importOpenApi(
+            UUID userId,
+            UUID projectId,
+            MultipartFile file
+    ) {
+
+        log.info(
+                "User {} started OpenAPI import for project {}",
+                userId,
+                projectId
+        );
+
+        // Ensure project exists
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() ->
+                        new ResourceNotFoundException("Project not found")
+                );
+
+        // Parse uploaded file
+        ParsedOpenApiSpec parsedSpec = parserService.parse(file);
+
+        // Validate parsed specification
+        validatorService.validate(parsedSpec);
+
+        // Store the results
+        List<MockSchemaResponse> importedSchemas = new ArrayList<>();
+        List<SkippedSchema> skippedSchemas = new ArrayList<>();
+
+        // Iterate through all reusable OpenAPI schemas
+        for (Map.Entry<String, Schema> entry :
+                parsedSpec.getSchemas().entrySet()) {
+
+            String componentName = entry.getKey();
+            Schema<?> openApiSchema = entry.getValue();
+
+            try {
+
+                // Convert OpenAPI schema to Mockify schemaJson
+                Map<String, Object> schemaJson =
+                        extractorService.extractSchema(
+                                componentName,
+                                openApiSchema
+                        );
+
+                /*
+                 * Build internal create request
+                 *
+                 * Original schema name becomes Mock Schema name
+                 */
+                CreateMockSchemaRequest request =
+                        new CreateMockSchemaRequest();
+
+                request.setName(componentName);
+                request.setSchemaJson(schemaJson);
+
+                /*
+                 * Use existing schema creation flow
+                 *
+                 * This automatically:
+                 * - validates schemaJson
+                 * - creates slug
+                 * - saves schema
+                 * - creates endpoint
+                 */
+                MockSchemaResponse created =
+                        mockSchemaService.createSchema(
+                                userId,
+                                project.getId(),
+                                request
+                        );
+
+                importedSchemas.add(created);
+
+                log.info(
+                        "Imported OpenAPI schema '{}' into project {}",
+                        componentName,
+                        projectId
+                );
+
+            } catch (Exception ex) {
+
+                /*
+                 * Partial failure strategy:
+                 * Skip invalid schema,
+                 * continue importing others
+                 */
+                log.warn("Skipping OpenAPI schema '{}' due to error: {}", componentName, ex.getMessage());
+
+                skippedSchemas.add(
+                        new SkippedSchema(componentName, ex.getMessage())
+                );
+            }
+        }
+
+        // Final summary log
+        log.info(
+                "OpenAPI import completed for project {} | imported={} | skipped={}",
+                projectId, importedSchemas.size(), skippedSchemas.size()
+        );
+
+        // Return summary response
+        return OpenApiImportResponse.of(
+                importedSchemas,
+                skippedSchemas
+        );
+    }
+}

--- a/src/main/java/com/mockify/backend/service/impl/OpenApiImportServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/OpenApiImportServiceImpl.java
@@ -17,10 +17,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import io.swagger.v3.oas.models.media.Schema;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+
+import java.util.*;
 
 /**
  * OpenApiImportService
@@ -199,10 +197,14 @@ public class OpenApiImportServiceImpl implements OpenApiImportService {
 
         String filename = file.getOriginalFilename();
 
+        // Convert the filename to lowercase before checking
+        String normalizedFilename =
+                filename == null ? null : filename.toLowerCase(Locale.ROOT);
+
         if (filename == null ||
-                (!filename.endsWith(".yaml") &&
-                        !filename.endsWith(".yml") &&
-                        !filename.endsWith(".json"))) {
+                (!normalizedFilename.endsWith(".yaml") &&
+                        !normalizedFilename.endsWith(".yml") &&
+                        !normalizedFilename.endsWith(".json"))) {
 
             throw new BadRequestException(
                     "Unsupported file type. Please upload .yaml, .yml, or .json files only."

--- a/src/main/java/com/mockify/backend/service/impl/OpenApiImportServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/OpenApiImportServiceImpl.java
@@ -5,6 +5,7 @@ import com.mockify.backend.dto.request.schema.CreateMockSchemaRequest;
 import com.mockify.backend.dto.response.imports.OpenApiImportResponse;
 import com.mockify.backend.dto.response.imports.SkippedSchema;
 import com.mockify.backend.dto.response.schema.MockSchemaResponse;
+import com.mockify.backend.exception.BadRequestException;
 import com.mockify.backend.exception.ResourceNotFoundException;
 import com.mockify.backend.model.Project;
 import com.mockify.backend.repository.ProjectRepository;
@@ -16,7 +17,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import io.swagger.v3.oas.models.media.Schema;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +51,8 @@ public class OpenApiImportServiceImpl implements OpenApiImportService {
     private final MockSchemaService mockSchemaService;
     private final ProjectRepository projectRepository;
 
+    private static final long MAX_FILE_SIZE = 2 * 1024 * 1024; // 2 MB
+
     /**
      * Import OpenAPI file and auto-generate mock schemas
      *
@@ -82,6 +84,9 @@ public class OpenApiImportServiceImpl implements OpenApiImportService {
                 .orElseThrow(() ->
                         new ResourceNotFoundException("Project not found")
                 );
+
+        // validate the file
+        validateFile(file);
 
         // Parse uploaded file
         ParsedOpenApiSpec parsedSpec = parserService.parse(file);
@@ -170,5 +175,44 @@ public class OpenApiImportServiceImpl implements OpenApiImportService {
                 importedSchemas,
                 skippedSchemas
         );
+    }
+
+
+    /**
+     * Validates uploaded OpenAPI specification file before parsing.
+     *
+     * Validation Rules:
+     * 1. File must be present and not empty
+     * 2. File extension must be one of:
+     *    - .yaml
+     *    - .yml
+     *    - .json
+     * 3. File size must not exceed configured maximum limit
+     *
+     * @param file uploaded multipart OpenAPI specification file
+     */
+    private void validateFile(MultipartFile file) {
+
+        if (file == null || file.isEmpty()) {
+            throw new BadRequestException("OpenAPI file is required");
+        }
+
+        String filename = file.getOriginalFilename();
+
+        if (filename == null ||
+                (!filename.endsWith(".yaml") &&
+                        !filename.endsWith(".yml") &&
+                        !filename.endsWith(".json"))) {
+
+            throw new BadRequestException(
+                    "Unsupported file type. Please upload .yaml, .yml, or .json files only."
+            );
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new BadRequestException(
+                    "File size exceeds maximum allowed limit of 2 MB."
+            );
+        }
     }
 }

--- a/src/main/java/com/mockify/backend/service/impl/OpenApiParserServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/OpenApiParserServiceImpl.java
@@ -1,0 +1,149 @@
+package com.mockify.backend.service.impl;
+
+import com.mockify.backend.dto.internal.ParsedOpenApiSpec;
+import com.mockify.backend.exception.InvalidOpenApiException;
+import com.mockify.backend.service.OpenApiParserService;
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OpenApiParserService
+ *
+ * Responsibility:
+ * - Accept uploaded OpenAPI/Swagger file
+ * - Parse JSON/YAML into OpenAPI object
+ * - Detect OpenAPI version
+ * - Extract schemas from:
+ *      OpenAPI 3.x -> components.schemas
+ *      Swagger 2.x -> definitions
+ * - Normalize into ParsedOpenApiSpec
+ *
+ * This service does NOT:
+ * - validate business rules
+ * - create schemas
+ * - save database records
+ *
+ * It only parses raw specification safely.
+ */
+@Service
+@Slf4j
+public class OpenApiParserServiceImpl implements OpenApiParserService {
+
+    /**
+     * Parse uploaded OpenAPI file into internal ParsedOpenApiSpec
+     *
+     * @param file uploaded swagger/openapi file
+     * @return normalized parsed specification
+     */
+    @Override
+    public ParsedOpenApiSpec parse(MultipartFile file) {
+
+        // Validate file existence before parsing
+        if (file == null || file.isEmpty()) {
+            throw new InvalidOpenApiException("Uploaded OpenAPI file is empty");
+        }
+
+        try {
+            // Convert uploaded file bytes into string content
+            // swagger-parser accepts raw YAML/JSON string
+            String content = new String(file.getBytes());
+
+            // Parse options:
+            // resolve = true -> resolve $ref references automatically
+            // flatten = false -> preserve structure
+            ParseOptions options = new ParseOptions();
+            options.setResolve(true);
+            options.setFlatten(false);
+
+            // Parse specification
+            SwaggerParseResult result = new OpenAPIParser()
+                    .readContents(content, null, options);
+
+            // Collect parsing messages/errors
+            List<String> messages = result.getMessages();
+
+            // If parser returns errors, reject file
+            if (messages != null && !messages.isEmpty()) {
+                log.error("OpenAPI parsing failed: {}", messages);
+                throw new InvalidOpenApiException(
+                        "Invalid OpenAPI specification: " + String.join(", ", messages)
+                );
+            }
+
+            OpenAPI openAPI = result.getOpenAPI();
+
+            // Null means parser failed to construct valid spec
+            if (openAPI == null) {
+                throw new InvalidOpenApiException("Unable to parse OpenAPI specification");
+            }
+
+            // Detect OpenAPI version
+            String version = openAPI.getOpenapi();
+
+            // If version missing, likely unsupported Swagger file
+            if (version == null || version.isBlank()) {
+                throw new InvalidOpenApiException(
+                        "Unsupported specification. Only OpenAPI 3.x is supported in MVP"
+                );
+            }
+
+            // Extract schemas from components section
+            Map<String, Schema> schemas = extractSchemas(openAPI);
+
+            log.info(
+                    "Successfully parsed OpenAPI file '{}' | version={} | schemas={}",
+                    file.getOriginalFilename(),
+                    version,
+                    schemas.size()
+            );
+
+            // Return normalized internal DTO
+            return new ParsedOpenApiSpec(
+                    version,
+                    schemas
+            );
+
+        } catch (IOException e) {
+            log.error("Failed to read uploaded OpenAPI file", e);
+            throw new InvalidOpenApiException("Failed to read OpenAPI file");
+        } catch (Exception e) {
+            log.error("Unexpected OpenAPI parsing failure", e);
+            throw new InvalidOpenApiException("Failed to parse OpenAPI specification");
+        }
+    }
+
+    /**
+     * Extract reusable schemas/components from OpenAPI specification
+     *
+     * OpenAPI 3:
+     * components.schemas
+     *
+     * Swagger 2:
+     * definitions (future enhancement)
+     *
+     * @param openAPI parsed OpenAPI object
+     * @return schema map
+     */
+    private Map<String, Schema> extractSchemas(OpenAPI openAPI) {
+
+        // Ensure components section exists
+        if (openAPI.getComponents() == null ||
+                openAPI.getComponents().getSchemas() == null) {
+
+            log.warn("No schemas found inside OpenAPI components");
+            return Collections.emptyMap();
+        }
+
+        return openAPI.getComponents().getSchemas();
+    }
+}

--- a/src/main/java/com/mockify/backend/service/impl/OpenApiParserServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/OpenApiParserServiceImpl.java
@@ -17,23 +17,23 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * OpenApiParserService
+ * Parse uploaded API specification into normalized internal ParsedOpenApiSpec.
  *
- * Responsibility:
- * - Accept uploaded OpenAPI/Swagger file
- * - Parse JSON/YAML into OpenAPI object
- * - Detect OpenAPI version
- * - Extract schemas from:
- *      OpenAPI 3.x -> components.schemas
- *      Swagger 2.x -> definitions
- * - Normalize into ParsedOpenApiSpec
+ * Supported:
+ * - OpenAPI 3.x
+ * - Swagger 2.0
  *
- * This service does NOT:
- * - validate business rules
- * - create schemas
- * - save database records
+ * Features:
+ * - YAML / JSON parsing
+ * - Automatic $ref resolution
+ * - Reusable schema extraction
+ * - Legacy Swagger compatibility
  *
- * It only parses raw specification safely.
+ * Security:
+ * - Defensive null/empty validation
+ * - Structural validation
+ * - Safe parser failure handling
+ *
  */
 @Service
 @Slf4j
@@ -48,7 +48,7 @@ public class OpenApiParserServiceImpl implements OpenApiParserService {
     @Override
     public ParsedOpenApiSpec parse(MultipartFile file) {
 
-        // Validate file existence before parsing
+        // Defensive validation
         if (file == null || file.isEmpty()) {
             throw new InvalidOpenApiException("Uploaded OpenAPI file is empty");
         }
@@ -87,18 +87,42 @@ public class OpenApiParserServiceImpl implements OpenApiParserService {
                 throw new InvalidOpenApiException("Unable to parse OpenAPI specification");
             }
 
-            // Detect OpenAPI version
-            String version = openAPI.getOpenapi();
+            /*
+             * Detect specification version.
+             *
+             * OpenAPI 3:
+             * openapi field
+             *
+             * Swagger 2:
+             * parser may normalize,
+             * so fallback to raw content detection.
+             */
+            String version;
 
-            // If version missing, likely unsupported Swagger file
-            if (version == null || version.isBlank()) {
+            if (openAPI.getOpenapi() != null &&
+                    !openAPI.getOpenapi().isBlank()) {
+
+                version = openAPI.getOpenapi();
+
+            } else if (content.contains("swagger: \"2.0\"") ||
+                    content.contains("swagger: '2.0'") ||
+                    content.contains("swagger: 2.0")) {
+
+                version = "2.0";
+
+            } else {
+
                 throw new InvalidOpenApiException(
-                        "Unsupported specification. Only OpenAPI 3.x is supported in MVP"
+                        "Unsupported or unknown API specification version"
                 );
             }
 
-            // Extract schemas from components section
-            Map<String, Schema> schemas = extractSchemas(openAPI);
+            /*
+             * Extract reusable schemas:
+             * - OpenAPI 3 -> components.schemas
+             * - Swagger 2 -> definitions
+             */
+            Map<String, Schema> schemas = extractSchemas(openAPI, version);
 
             log.info(
                     "Successfully parsed OpenAPI file '{}' | version={} | schemas={}",
@@ -129,21 +153,38 @@ public class OpenApiParserServiceImpl implements OpenApiParserService {
      * components.schemas
      *
      * Swagger 2:
-     * definitions (future enhancement)
+     * definitions
      *
      * @param openAPI parsed OpenAPI object
      * @return schema map
      */
-    private Map<String, Schema> extractSchemas(OpenAPI openAPI) {
+    private Map<String, Schema> extractSchemas(OpenAPI openAPI, String version) {
 
-        // Ensure components section exists
-        if (openAPI.getComponents() == null ||
-                openAPI.getComponents().getSchemas() == null) {
+        /*
+         * Primary extraction:
+         * OpenAPI 3 components
+         */
+        if (openAPI.getComponents() != null &&
+                openAPI.getComponents().getSchemas() != null) {
 
-            log.warn("No schemas found inside OpenAPI components");
+            return openAPI.getComponents().getSchemas();
+        }
+
+        /*
+         * Swagger 2 fallback:
+         * Parser often converts definitions automatically,
+         * but if schemas are absent,
+         * return empty map gracefully.
+         */
+        if ("2.0".equals(version)) {
+
+            log.warn("Swagger 2.0 specification parsed, but no reusable definitions found");
+
             return Collections.emptyMap();
         }
 
-        return openAPI.getComponents().getSchemas();
+        log.warn("No reusable schemas found inside specification");
+
+        return Collections.emptyMap();
     }
 }

--- a/src/main/java/com/mockify/backend/service/impl/OpenApiParserServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/OpenApiParserServiceImpl.java
@@ -140,6 +140,8 @@ public class OpenApiParserServiceImpl implements OpenApiParserService {
         } catch (IOException e) {
             log.error("Failed to read uploaded OpenAPI file", e);
             throw new InvalidOpenApiException("Failed to read OpenAPI file");
+        }catch (InvalidOpenApiException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Unexpected OpenAPI parsing failure", e);
             throw new InvalidOpenApiException("Failed to parse OpenAPI specification");

--- a/src/main/java/com/mockify/backend/service/impl/OpenApiValidatorServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/OpenApiValidatorServiceImpl.java
@@ -1,0 +1,261 @@
+package com.mockify.backend.service.impl;
+
+import com.mockify.backend.dto.internal.ParsedOpenApiSpec;
+import com.mockify.backend.exception.InvalidOpenApiException;
+import com.mockify.backend.service.OpenApiValidatorService;
+import io.swagger.v3.oas.models.media.Schema;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * OpenApiValidatorService
+ *
+ * Responsibility:
+ * - Validate already parsed OpenAPI specification
+ * - Ensure required schema structure exists
+ * - Reject unsupported formats early
+ * - Prevent invalid schema imports before DB creation
+ *
+ * This service validates:
+ * - OpenAPI version
+ * - Components existence
+ * - Schema definitions
+ * - Schema names
+ * - Property presence
+ * - Supported field types
+ *
+ * This service does NOT:
+ * - Parse raw files
+ * - Convert schema fields
+ * - Save mock schemas
+ */
+@Service
+@Slf4j
+public class OpenApiValidatorServiceImpl implements OpenApiValidatorService {
+
+    /**
+     * Supported primitive OpenAPI types for MVP
+     *
+     * Future:
+     * - oneOf
+     * - anyOf
+     * - allOf
+     * - enum
+     * - advanced refs
+     */
+    private static final Set<String> SUPPORTED_TYPES = Set.of(
+            "string",
+            "integer",
+            "number",
+            "boolean",
+            "array",
+            "object"
+    );
+
+    /**
+     * Validate entire parsed OpenAPI specification
+     *
+     * @param spec normalized parsed spec
+     */
+    public void validate(ParsedOpenApiSpec spec) {
+
+        // Basic null check
+        if (spec == null) {
+            throw new InvalidOpenApiException("Parsed OpenAPI specification is null");
+        }
+
+        validateVersion(spec.getVersion());
+        validateSchemasExist(spec.getSchemas());
+        validateEachSchema(spec.getSchemas());
+
+        log.info(
+                "OpenAPI validation successful | version={} | schemas={}",
+                spec.getVersion(), spec.getSchemas().size()
+        );
+    }
+
+    /**
+     * Validate supported OpenAPI version
+     *
+     * MVP supports:
+     * - OpenAPI 3.x
+     *
+     * Future:
+     * - Swagger 2.0
+     */
+    private void validateVersion(String version) {
+
+        if (version == null || version.isBlank()) {
+            throw new InvalidOpenApiException("Missing OpenAPI version");
+        }
+
+        // Accept only 3.x specs
+        if (!version.startsWith("3")) {
+            throw new InvalidOpenApiException(
+                    "Unsupported OpenAPI version: " + version +
+                            ". Only OpenAPI 3.x is supported"
+            );
+        }
+    }
+
+    /**
+     * Ensure schemas/components section exists
+     */
+    private void validateSchemasExist(Map<String, Schema> schemas) {
+
+        if (schemas == null || schemas.isEmpty()) {
+            throw new InvalidOpenApiException(
+                    "No reusable schemas found in OpenAPI components"
+            );
+        }
+    }
+
+    /**
+     * Validate all schema components
+     */
+    private void validateEachSchema(Map<String, Schema> schemas) {
+
+        for (Map.Entry<String, Schema> entry : schemas.entrySet()) {
+
+            String schemaName = entry.getKey();
+            Schema schema = entry.getValue();
+
+            validateSchemaName(schemaName);
+            validateSchemaStructure(schemaName, schema);
+        }
+    }
+
+    /**
+     * Validate schema component name
+     *
+     * Example:
+     * User
+     * Product
+     * BlogPost
+     */
+    private void validateSchemaName(String schemaName) {
+
+        if (schemaName == null || schemaName.isBlank()) {
+            throw new InvalidOpenApiException("Schema name cannot be empty");
+        }
+
+        // Prevent dangerous or malformed names
+        if (schemaName.length() > 100) {
+            throw new InvalidOpenApiException(
+                    "Schema name too long: " + schemaName
+            );
+        }
+    }
+
+    /**
+     * Validate schema structure
+     *
+     * MVP expects:
+     * type: object
+     * properties: {}
+     */
+    private void validateSchemaStructure(String schemaName, Schema schema) {
+
+        if (schema == null) {
+            throw new InvalidOpenApiException(
+                    "Schema definition missing for component: " + schemaName
+            );
+        }
+
+        // Root schema must contain properties
+        if (schema.getProperties() == null || schema.getProperties().isEmpty()) {
+            throw new InvalidOpenApiException(
+                    "Schema '" + schemaName + "' contains no properties"
+            );
+        }
+
+        // Validate each property
+        for (Object propertyKey : schema.getProperties().keySet()) {
+
+            String propertyName = propertyKey.toString();
+            Schema propertySchema =
+                    (Schema) schema.getProperties().get(propertyKey);
+
+            validateProperty(schemaName, propertyName, propertySchema);
+        }
+    }
+
+    /**
+     * Validate individual property
+     */
+    private void validateProperty(
+            String schemaName,
+            String propertyName,
+            Schema propertySchema
+    ) {
+
+        if (propertyName == null || propertyName.isBlank()) {
+            throw new InvalidOpenApiException(
+                    "Schema '" + schemaName + "' contains invalid property name"
+            );
+        }
+
+        if (propertySchema == null) {
+            throw new InvalidOpenApiException(
+                    "Property '" + propertyName +
+                            "' in schema '" + schemaName +
+                            "' is missing definition"
+            );
+        }
+
+        /*
+         * $ref schemas may not contain direct type
+         * Allow them for parser resolution
+         */
+        if (propertySchema.get$ref() != null) {
+            return;
+        }
+
+        String type = propertySchema.getType();
+
+        // Type required
+        if (type == null || type.isBlank()) {
+            throw new InvalidOpenApiException(
+                    "Property '" + propertyName +
+                            "' in schema '" + schemaName +
+                            "' is missing type"
+            );
+        }
+
+        // Reject unsupported types
+        if (!SUPPORTED_TYPES.contains(type)) {
+            throw new InvalidOpenApiException(
+                    "Unsupported property type '" + type +
+                            "' in schema '" + schemaName +
+                            "', property '" + propertyName + "'"
+            );
+        }
+
+        /*
+         * Array validation:
+         * Ensure item type exists
+         */
+        if ("array".equals(type)) {
+
+            if (propertySchema.getItems() == null) {
+                throw new InvalidOpenApiException(
+                        "Array property '" + propertyName +
+                                "' in schema '" + schemaName +
+                                "' is missing item definition"
+                );
+            }
+        }
+
+        /*
+         * Object validation:
+         * Nested object allowed
+         */
+        if ("object".equals(type)) {
+
+            // Empty nested object allowed for MVP
+            // Future can recursively validate nested objects
+        }
+    }
+}

--- a/src/main/java/com/mockify/backend/service/impl/OpenApiValidatorServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/OpenApiValidatorServiceImpl.java
@@ -81,9 +81,10 @@ public class OpenApiValidatorServiceImpl implements OpenApiValidatorService {
      *
      * MVP supports:
      * - OpenAPI 3.x
+     * - Swagger 2.0
      *
      * Future:
-     * - Swagger 2.0
+     * JSON
      */
     private void validateVersion(String version) {
 

--- a/src/main/java/com/mockify/backend/service/impl/OpenApiValidatorServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/OpenApiValidatorServiceImpl.java
@@ -92,11 +92,11 @@ public class OpenApiValidatorServiceImpl implements OpenApiValidatorService {
             throw new InvalidOpenApiException("Missing OpenAPI version");
         }
 
-        // Accept only 3.x specs
-        if (!version.startsWith("3")) {
+        // Accept OpenAPI 3.x and Swagger 2.0
+        if (!(version.startsWith("3") || "2.0".equals(version))) {
             throw new InvalidOpenApiException(
                     "Unsupported OpenAPI version: " + version +
-                            ". Only OpenAPI 3.x is supported"
+                            ". Only OpenAPI 3.x and Swagger 2.0 are supported"
             );
         }
     }

--- a/src/main/java/com/mockify/backend/service/impl/SchemaExtractorServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/SchemaExtractorServiceImpl.java
@@ -1,0 +1,263 @@
+package com.mockify.backend.service.impl;
+
+import com.mockify.backend.service.SchemaExtractorService;
+import io.swagger.v3.oas.models.media.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * SchemaExtractorService
+ *
+ * Responsibility:
+ * - Convert validated OpenAPI schema properties
+ *   into Mockify-compatible schemaJson format
+ *
+ * Example:
+ *
+ * OpenAPI:
+ * User:
+ *   properties:
+ *     id:
+ *       type: string
+ *       format: uuid
+ *     email:
+ *       type: string
+ *       format: email
+ *
+ * Output:
+ * {
+ *   "id": "uuid",
+ *   "email": "email"
+ * }
+ *
+ * This service:
+ * - Maps OpenAPI primitive types
+ * - Handles formats
+ * - Supports nested objects
+ * - Supports arrays
+ * - Supports resolved $ref schemas
+ *
+ * This service does NOT:
+ * - Validate OpenAPI spec
+ * - Save DB records
+ * - Create endpoints
+ */
+@Service
+@Slf4j
+public class SchemaExtractorServiceImpl implements SchemaExtractorService {
+
+    /**
+     * Extract complete schemaJson for one OpenAPI component
+     *
+     * @param schemaName component name
+     * @param schema OpenAPI schema object
+     * @return Mockify schema JSON structure
+     */
+    @Override
+    public Map<String, Object> extractSchema(String schemaName, Schema<?> schema) {
+
+        if (schema == null || schema.getProperties() == null) {
+            throw new IllegalArgumentException(
+                    "Schema '" + schemaName + "' contains no extractable properties"
+            );
+        }
+
+        Map<String, Object> extracted = new LinkedHashMap<>();
+
+        // Preserve field order from OpenAPI spec
+        for (Map.Entry<String, Schema> property :
+                (Iterable<Map.Entry<String, Schema>>) schema.getProperties().entrySet()) {
+
+            String propertyName = property.getKey();
+            Schema<?> propertySchema = property.getValue();
+
+            extracted.put(
+                    propertyName,
+                    extractPropertyType(propertySchema)
+            );
+        }
+
+        log.info(
+                "Extracted schema '{}' with {} fields",
+                schemaName,
+                extracted.size()
+        );
+
+        return extracted;
+    }
+
+    /**
+     * Extract property type recursively
+     *
+     * Handles:
+     * - string
+     * - integer
+     * - boolean
+     * - number
+     * - array
+     * - object
+     * - $ref
+     */
+    private Object extractPropertyType(Schema<?> propertySchema) {
+
+        /*
+         * Handle resolved references
+         *
+         * Example:
+         * author:
+         *   $ref: '#/components/schemas/User'
+         *
+         * After parser resolution,
+         * referenced schema behaves like normal object schema
+         */
+        if (propertySchema.get$ref() != null) {
+
+            // Simplified MVP:
+            // treat referenced schema as nested object
+            return "object";
+        }
+
+        String type = propertySchema.getType();
+
+        if (type == null) {
+
+            // Sometimes parser resolves schemas
+            // without direct type but with properties
+            if (propertySchema.getProperties() != null) {
+                return extractNestedObject(propertySchema);
+            }
+
+            return "string";
+        }
+
+        // Data types handling
+        return switch (type) {
+
+            case "string" -> mapStringType(propertySchema);
+
+            case "integer", "number" -> "number";
+
+            case "boolean" -> "boolean";
+
+            case "array" -> extractArrayType(propertySchema);
+
+            case "object" -> extractNestedObject(propertySchema);
+
+            default -> "string";
+        };
+    }
+
+    /**
+     * Map string formats into Mockify-specific types
+     *
+     * OpenAPI:
+     * - uuid
+     * - email
+     * - date-time
+     */
+    private String mapStringType(Schema<?> schema) {
+
+        String format = schema.getFormat();
+
+        if (format == null) {
+            return "string";
+        }
+
+        return switch (format.toLowerCase()) {
+
+            case "uuid" -> "uuid";
+
+            case "email" -> "email";
+
+            case "date-time", "datetime" -> "datetime";
+
+            case "date" -> "date";
+
+            case "uri", "url" -> "url";
+
+            default -> "string";
+        };
+    }
+
+    /**
+     * Extract array structure
+     *
+     * Example:
+     * tags:
+     *   type: array
+     *   items:
+     *     type: string
+     *
+     * Output:
+     * {
+     *   "type": "array",
+     *   "items": "string"
+     * }
+     */
+    private Map<String, Object> extractArrayType(Schema<?> schema) {
+
+        Map<String, Object> arrayDefinition = new LinkedHashMap<>();
+
+        arrayDefinition.put("type", "array");
+
+        Schema<?> itemSchema = schema.getItems();
+
+        if (itemSchema == null) {
+
+            // Default fallback
+            arrayDefinition.put("items", "string");
+
+            return arrayDefinition;
+        }
+
+        arrayDefinition.put(
+                "items",
+                extractPropertyType(itemSchema)
+        );
+
+        return arrayDefinition;
+    }
+
+    /**
+     * Extract nested object recursively
+     *
+     * Example:
+     * profile:
+     *   type: object
+     *   properties:
+     *     age:
+     *       type: integer
+     *
+     * Output:
+     * {
+     *   "age": "number"
+     * }
+     */
+    private Map<String, Object> extractNestedObject(Schema<?> schema) {
+
+        Map<String, Object> nested = new LinkedHashMap<>();
+
+        if (schema.getProperties() == null || schema.getProperties().isEmpty()) {
+
+            /*
+             * Empty object fallback
+             */
+            nested.put("type", "object");
+            return nested;
+        }
+
+        for (Map.Entry<String, Schema> property :
+                (Iterable<Map.Entry<String, Schema>>) schema.getProperties().entrySet()) {
+
+            nested.put(
+                    property.getKey(),
+                    extractPropertyType(property.getValue())
+            );
+        }
+
+        return nested;
+    }
+}

--- a/src/test/java/com/mockify/backend/controller/OpenApiImportControllerTest.java
+++ b/src/test/java/com/mockify/backend/controller/OpenApiImportControllerTest.java
@@ -1,0 +1,290 @@
+package com.mockify.backend.controller;
+
+import com.mockify.backend.dto.response.imports.OpenApiImportResponse;
+import com.mockify.backend.security.SecurityUtils;
+import com.mockify.backend.service.EndpointService;
+import com.mockify.backend.service.OpenApiImportService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.UUID;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * OpenApiImportControllerTest
+ *
+ * Purpose:
+ * - Validate endpoint routing
+ * - Validate multipart upload
+ * - Validate authentication flow
+ * - Validate org/project resolution
+ * - Validate HTTP status codes
+ */
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@Transactional
+class OpenApiImportControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OpenApiImportService openApiImportService;
+
+    @MockitoBean
+    private EndpointService endpointService;
+
+
+    /**
+     * Helper:
+     * Build valid multipart file
+     */
+    private MockMultipartFile buildValidFile() {
+
+        return new MockMultipartFile(
+                "file",
+                "openapi.yaml",
+                "application/x-yaml",
+                """
+                openapi: 3.0.3
+                info:
+                  title: Test API
+                  version: 1.0.0
+                """.getBytes()
+        );
+    }
+
+
+    @Nested
+    @DisplayName("Successful Controller Tests")
+    class SuccessfulControllerTests {
+
+        @Test
+        @DisplayName("Should import valid OpenAPI file successfully")
+        void shouldImportValidOpenApiSuccessfully()
+                throws Exception {
+
+            UUID userId = UUID.randomUUID();
+            UUID projectId = UUID.randomUUID();
+
+            OpenApiImportResponse response =
+                    OpenApiImportResponse.of(
+                            Collections.emptyList(),
+                            Collections.emptyList()
+                    );
+
+            when(endpointService.resolveProject(
+                    "test-org",
+                    "test-project"
+            )).thenReturn(projectId);
+
+            when(openApiImportService.importOpenApi(
+                    eq(userId),
+                    eq(projectId),
+                    any()
+            )).thenReturn(response);
+
+            try (MockedStatic<SecurityUtils> securityMock =
+                         mockStatic(SecurityUtils.class)) {
+
+                Authentication auth =
+                        mock(Authentication.class);
+
+                securityMock.when(
+                        () -> SecurityUtils.resolveUserId(auth)
+                ).thenReturn(userId);
+
+                mockMvc.perform(
+                                multipart(
+                                        "/api/test-org/test-project/import/openapi"
+                                )
+                                        .file(buildValidFile())
+                                        .principal(auth)
+                                        .contentType(
+                                                MediaType.MULTIPART_FORM_DATA
+                                        )
+                        )
+                        .andExpect(status().isCreated())
+                        .andExpect(
+                                content().contentType(
+                                        MediaType.APPLICATION_JSON
+                                )
+                        )
+                        .andExpect(
+                                jsonPath("$.totalImported").value(0)
+                        )
+                        .andExpect(
+                                jsonPath("$.totalSkipped").value(0)
+                        );
+            }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Project Resolution Failure Tests")
+    class ProjectResolutionFailureTests {
+
+        @Test
+        @DisplayName("Should return 404 when project not found")
+        void shouldReturn404WhenProjectMissing()
+                throws Exception {
+
+            Authentication auth =
+                    mock(Authentication.class);
+
+            when(endpointService.resolveProject(
+                    "test-org",
+                    "missing-project"
+            )).thenThrow(
+                    new RuntimeException("Project not found")
+            );
+
+            try (MockedStatic<SecurityUtils> securityMock =
+                         mockStatic(SecurityUtils.class)) {
+
+                securityMock.when(
+                        () -> SecurityUtils.resolveUserId(auth)
+                ).thenReturn(UUID.randomUUID());
+
+                mockMvc.perform(
+                                multipart(
+                                        "/api/test-org/missing-project/import/openapi"
+                                )
+                                        .file(buildValidFile())
+                                        .principal(auth)
+                        )
+                        .andExpect(status().is5xxServerError());
+            }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Service Failure Tests")
+    class ServiceFailureTests {
+
+        @Test
+        @DisplayName("Should propagate service validation errors")
+        void shouldPropagateServiceValidationErrors()
+                throws Exception {
+
+            UUID userId = UUID.randomUUID();
+            UUID projectId = UUID.randomUUID();
+
+            when(endpointService.resolveProject(
+                    anyString(),
+                    anyString()
+            )).thenReturn(projectId);
+
+            when(openApiImportService.importOpenApi(
+                    eq(userId),
+                    eq(projectId),
+                    any()
+            )).thenThrow(
+                    new RuntimeException("Import failed")
+            );
+
+            Authentication auth =
+                    mock(Authentication.class);
+
+            try (MockedStatic<SecurityUtils> securityMock =
+                         mockStatic(SecurityUtils.class)) {
+
+                securityMock.when(
+                        () -> SecurityUtils.resolveUserId(auth)
+                ).thenReturn(userId);
+
+                mockMvc.perform(
+                                multipart(
+                                        "/api/test-org/test-project/import/openapi"
+                                )
+                                        .file(buildValidFile())
+                                        .principal(auth)
+                        )
+                        .andExpect(status().is5xxServerError());
+            }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Interaction Verification Tests")
+    class InteractionVerificationTests {
+
+        @Test
+        @DisplayName("Should call service with correct parameters")
+        void shouldCallServiceWithCorrectParameters()
+                throws Exception {
+
+            UUID userId = UUID.randomUUID();
+            UUID projectId = UUID.randomUUID();
+
+            when(endpointService.resolveProject(
+                    "test-org",
+                    "test-project"
+            )).thenReturn(projectId);
+
+            when(openApiImportService.importOpenApi(
+                    any(),
+                    any(),
+                    any()
+            )).thenReturn(
+                    OpenApiImportResponse.of(
+                            Collections.emptyList(),
+                            Collections.emptyList()
+                    )
+            );
+
+            Authentication auth =
+                    mock(Authentication.class);
+
+            try (MockedStatic<SecurityUtils> securityMock =
+                         mockStatic(SecurityUtils.class)) {
+
+                securityMock.when(
+                        () -> SecurityUtils.resolveUserId(auth)
+                ).thenReturn(userId);
+
+                mockMvc.perform(
+                                multipart(
+                                        "/api/test-org/test-project/import/openapi"
+                                )
+                                        .file(buildValidFile())
+                                        .principal(auth)
+                        )
+                        .andExpect(status().isCreated());
+
+                verify(endpointService)
+                        .resolveProject(
+                                "test-org",
+                                "test-project"
+                        );
+
+                verify(openApiImportService)
+                        .importOpenApi(
+                                eq(userId),
+                                eq(projectId),
+                                any()
+                        );
+            }
+        }
+    }
+}

--- a/src/test/java/com/mockify/backend/controller/OpenApiImportControllerTest.java
+++ b/src/test/java/com/mockify/backend/controller/OpenApiImportControllerTest.java
@@ -1,6 +1,7 @@
 package com.mockify.backend.controller;
 
 import com.mockify.backend.dto.response.imports.OpenApiImportResponse;
+import com.mockify.backend.exception.ResourceNotFoundException;
 import com.mockify.backend.security.SecurityUtils;
 import com.mockify.backend.service.EndpointService;
 import com.mockify.backend.service.OpenApiImportService;
@@ -18,7 +19,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.Collections;
 import java.util.UUID;
 import static org.mockito.ArgumentMatchers.*;
@@ -154,7 +154,7 @@ class OpenApiImportControllerTest {
                     "test-org",
                     "missing-project"
             )).thenThrow(
-                    new RuntimeException("Project not found")
+                    new ResourceNotFoundException("Project not found")
             );
 
             try (MockedStatic<SecurityUtils> securityMock =
@@ -171,7 +171,7 @@ class OpenApiImportControllerTest {
                                         .file(buildValidFile())
                                         .principal(auth)
                         )
-                        .andExpect(status().is5xxServerError());
+                        .andExpect(status().isNotFound());
             }
         }
     }

--- a/src/test/java/com/mockify/backend/service/MockAutoGenerateServiceImplTest.java
+++ b/src/test/java/com/mockify/backend/service/MockAutoGenerateServiceImplTest.java
@@ -104,7 +104,7 @@ class MockAutoGenerateServiceImplTest {
                 "age", "number",
                 "active", "boolean",
                 "birthDate", "date",
-                "eventTime", "date-time",
+                "eventTime", "datetime",
                 "tags", "array",
                 "metadata", "object"
         );

--- a/src/test/java/com/mockify/backend/service/open_api_import/MockValidatorServiceTest.java
+++ b/src/test/java/com/mockify/backend/service/open_api_import/MockValidatorServiceTest.java
@@ -1,0 +1,600 @@
+package com.mockify.backend.service.open_api_import;
+
+import com.mockify.backend.exception.BadRequestException;
+import com.mockify.backend.service.MockValidatorService;
+import com.mockify.backend.service.impl.MockValidatorServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * MockValidatorServiceTest
+ *
+ * Purpose:
+ * - Validate schema definitions
+ * - Validate records against schemas
+ * - Verify nested objects
+ * - Verify arrays
+ * - Verify enum handling
+ * - Verify URL / UUID / Email / Datetime
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class MockValidatorServiceTest {
+
+    private MockValidatorService validatorService;
+
+    @BeforeEach
+    void setUp() {
+        validatorService = new MockValidatorServiceImpl();
+    }
+
+    /**
+     * Helper:
+     * Build valid primitive schema
+     */
+    private Map<String, Object> buildBasicSchema() {
+
+        Map<String, Object> schema =
+                new LinkedHashMap<>();
+
+        schema.put("id", "uuid");
+        schema.put("name", "string");
+        schema.put("email", "email");
+        schema.put("active", "boolean");
+        schema.put("createdAt", "datetime");
+
+        return schema;
+    }
+
+
+    @Nested
+    @DisplayName("Schema Definition Validation Tests")
+    class SchemaDefinitionValidationTests {
+
+        @Test
+        @DisplayName("Should validate primitive schema")
+        void shouldValidatePrimitiveSchema() {
+
+            Map<String, Object> schema =
+                    buildBasicSchema();
+
+            assertDoesNotThrow(
+                    () -> validatorService.validateSchemaDefinition(schema)
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should validate nested object schema")
+        void shouldValidateNestedObjectSchema() {
+
+            Map<String, Object> profile =
+                    new LinkedHashMap<>();
+
+            profile.put("age", "number");
+            profile.put("gender", "string");
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("profile", profile);
+
+            assertDoesNotThrow(
+                    () -> validatorService.validateSchemaDefinition(schema)
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should validate array schema")
+        void shouldValidateArraySchema() {
+
+            Map<String, Object> tags =
+                    new LinkedHashMap<>();
+
+            tags.put("type", "array");
+            tags.put("items", "string");
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("tags", tags);
+
+            assertDoesNotThrow(
+                    () -> validatorService.validateSchemaDefinition(schema)
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should validate enum schema")
+        void shouldValidateEnumSchema() {
+
+            Map<String, Object> status =
+                    new LinkedHashMap<>();
+
+            status.put("type", "enum");
+            status.put(
+                    "values",
+                    List.of("PENDING", "PAID", "FAILED")
+            );
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("status", status);
+
+            assertDoesNotThrow(
+                    () -> validatorService.validateSchemaDefinition(schema)
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject empty schema")
+        void shouldRejectEmptySchema() {
+
+            BadRequestException ex =
+                    assertThrows(
+                            BadRequestException.class,
+                            () -> validatorService.validateSchemaDefinition(
+                                    new LinkedHashMap<>()
+                            )
+                    );
+
+            assertEquals(
+                    "Schema JSON cannot be empty",
+                    ex.getMessage()
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject invalid type")
+        void shouldRejectInvalidType() {
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("avatar", "file");
+
+            BadRequestException ex =
+                    assertThrows(
+                            BadRequestException.class,
+                            () -> validatorService.validateSchemaDefinition(schema)
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "Invalid type"
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject enum without values")
+        void shouldRejectEnumWithoutValues() {
+
+            Map<String, Object> status =
+                    new LinkedHashMap<>();
+
+            status.put("type", "enum");
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("status", status);
+
+            BadRequestException ex =
+                    assertThrows(
+                            BadRequestException.class,
+                            () -> validatorService.validateSchemaDefinition(schema)
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "must define non-empty values"
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject array without items")
+        void shouldRejectArrayWithoutItems() {
+
+            Map<String, Object> tags =
+                    new LinkedHashMap<>();
+
+            tags.put("type", "array");
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("tags", tags);
+
+            BadRequestException ex =
+                    assertThrows(
+                            BadRequestException.class,
+                            () -> validatorService.validateSchemaDefinition(schema)
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "must define items"
+                    )
+            );
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Record Validation Success Tests")
+    class RecordValidationSuccessTests {
+
+        @Test
+        @DisplayName("Should validate valid primitive record")
+        void shouldValidateValidPrimitiveRecord() {
+
+            Map<String, Object> schema =
+                    buildBasicSchema();
+
+            Map<String, Object> record =
+                    new LinkedHashMap<>();
+
+            record.put(
+                    "id",
+                    UUID.randomUUID().toString()
+            );
+
+            record.put("name", "Sadab");
+            record.put("email", "sadab@example.com");
+            record.put("active", true);
+            record.put(
+                    "createdAt",
+                    "2026-05-16T10:15:30+00:00"
+            );
+
+            assertDoesNotThrow(
+                    () -> validatorService.validateRecordAgainstSchema(
+                            schema,
+                            record
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should validate nested object record")
+        void shouldValidateNestedObjectRecord() {
+
+            Map<String, Object> profile =
+                    new LinkedHashMap<>();
+
+            profile.put("age", "number");
+            profile.put("gender", "string");
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("profile", profile);
+
+            Map<String, Object> profileRecord =
+                    new LinkedHashMap<>();
+
+            profileRecord.put("age", 25);
+            profileRecord.put("gender", "Male");
+
+            Map<String, Object> record =
+                    new LinkedHashMap<>();
+
+            record.put("profile", profileRecord);
+
+            assertDoesNotThrow(
+                    () -> validatorService.validateRecordAgainstSchema(
+                            schema,
+                            record
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should validate URL field")
+        void shouldValidateUrlField() {
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("website", "url");
+
+            Map<String, Object> record =
+                    new LinkedHashMap<>();
+
+            record.put(
+                    "website",
+                    "https://mockify.com"
+            );
+
+            assertDoesNotThrow(
+                    () -> validatorService.validateRecordAgainstSchema(
+                            schema,
+                            record
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should validate enum record")
+        void shouldValidateEnumRecord() {
+
+            Map<String, Object> status =
+                    new LinkedHashMap<>();
+
+            status.put("type", "enum");
+            status.put(
+                    "values",
+                    List.of("PENDING", "PAID")
+            );
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("status", status);
+
+            Map<String, Object> record =
+                    new LinkedHashMap<>();
+
+            record.put("status", "PAID");
+
+            assertDoesNotThrow(
+                    () -> validatorService.validateRecordAgainstSchema(
+                            schema,
+                            record
+                    )
+            );
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Record Validation Failure Tests")
+    class RecordValidationFailureTests {
+
+        @Test
+        @DisplayName("Should reject missing required field")
+        void shouldRejectMissingField() {
+
+            Map<String, Object> schema =
+                    buildBasicSchema();
+
+            Map<String, Object> record =
+                    new LinkedHashMap<>();
+
+            record.put("name", "Sadab");
+
+            BadRequestException ex =
+                    assertThrows(
+                            BadRequestException.class,
+                            () -> validatorService.validateRecordAgainstSchema(
+                                    schema,
+                                    record
+                            )
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "Missing field"
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject invalid email")
+        void shouldRejectInvalidEmail() {
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("email", "email");
+
+            Map<String, Object> record =
+                    new LinkedHashMap<>();
+
+            record.put("email", "invalid-email");
+
+            BadRequestException ex =
+                    assertThrows(
+                            BadRequestException.class,
+                            () -> validatorService.validateRecordAgainstSchema(
+                                    schema,
+                                    record
+                            )
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "Invalid email format"
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject invalid UUID")
+        void shouldRejectInvalidUuid() {
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("id", "uuid");
+
+            Map<String, Object> record =
+                    new LinkedHashMap<>();
+
+            record.put("id", "123");
+
+            BadRequestException ex =
+                    assertThrows(
+                            BadRequestException.class,
+                            () -> validatorService.validateRecordAgainstSchema(
+                                    schema,
+                                    record
+                            )
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "Invalid UUID format"
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject invalid datetime")
+        void shouldRejectInvalidDatetime() {
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("createdAt", "datetime");
+
+            Map<String, Object> record =
+                    new LinkedHashMap<>();
+
+            record.put("createdAt", "invalid-date");
+
+            BadRequestException ex =
+                    assertThrows(
+                            BadRequestException.class,
+                            () -> validatorService.validateRecordAgainstSchema(
+                                    schema,
+                                    record
+                            )
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "Invalid datetime format"
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject invalid URL")
+        void shouldRejectInvalidUrl() {
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("website", "url");
+
+            Map<String, Object> record =
+                    new LinkedHashMap<>();
+
+            record.put("website", "ht!tp://bad-url");
+
+            BadRequestException ex =
+                    assertThrows(
+                            BadRequestException.class,
+                            () -> validatorService.validateRecordAgainstSchema(
+                                    schema,
+                                    record
+                            )
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "Invalid URL format"
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject invalid enum value")
+        void shouldRejectInvalidEnumValue() {
+
+            Map<String, Object> status =
+                    new LinkedHashMap<>();
+
+            status.put("type", "enum");
+            status.put(
+                    "values",
+                    List.of("PENDING", "PAID")
+            );
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("status", status);
+
+            Map<String, Object> record =
+                    new LinkedHashMap<>();
+
+            record.put("status", "FAILED");
+
+            BadRequestException ex =
+                    assertThrows(
+                            BadRequestException.class,
+                            () -> validatorService.validateRecordAgainstSchema(
+                                    schema,
+                                    record
+                            )
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "Invalid enum value"
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject extra fields")
+        void shouldRejectExtraFields() {
+
+            Map<String, Object> schema =
+                    new LinkedHashMap<>();
+
+            schema.put("name", "string");
+
+            Map<String, Object> record =
+                    new LinkedHashMap<>();
+
+            record.put("name", "Sadab");
+            record.put("extra", "not allowed");
+
+            BadRequestException ex =
+                    assertThrows(
+                            BadRequestException.class,
+                            () -> validatorService.validateRecordAgainstSchema(
+                                    schema,
+                                    record
+                            )
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "not allowed"
+                    )
+            );
+        }
+    }
+}

--- a/src/test/java/com/mockify/backend/service/open_api_import/OpenApiImportServiceTest.java
+++ b/src/test/java/com/mockify/backend/service/open_api_import/OpenApiImportServiceTest.java
@@ -1,0 +1,531 @@
+package com.mockify.backend.service.open_api_import;
+
+import com.mockify.backend.dto.internal.ParsedOpenApiSpec;
+import com.mockify.backend.dto.request.schema.CreateMockSchemaRequest;
+import com.mockify.backend.dto.response.imports.OpenApiImportResponse;
+import com.mockify.backend.dto.response.schema.MockSchemaResponse;
+import com.mockify.backend.exception.BadRequestException;
+import com.mockify.backend.exception.InvalidOpenApiException;
+import com.mockify.backend.exception.ResourceNotFoundException;
+import com.mockify.backend.model.Project;
+import com.mockify.backend.repository.ProjectRepository;
+import com.mockify.backend.service.*;
+import com.mockify.backend.service.impl.OpenApiImportServiceImpl;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * OpenApiImportServiceTest
+ *
+ * Purpose:
+ * - Validate orchestration layer
+ * - Validate file rules
+ * - Validate parser + validator + extractor integration
+ * - Validate partial import behavior
+ * - Validate skipped schemas
+ */
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class OpenApiImportServiceTest {
+
+    private OpenApiParserService parserService;
+    private OpenApiValidatorService validatorService;
+    private SchemaExtractorService extractorService;
+    private MockSchemaService mockSchemaService;
+    private ProjectRepository projectRepository;
+
+    private OpenApiImportService importService;
+
+    private UUID userId;
+    private UUID projectId;
+    private Project project;
+
+    @BeforeEach
+    void setUp() {
+
+        parserService = mock(OpenApiParserService.class);
+        validatorService = mock(OpenApiValidatorService.class);
+        extractorService = mock(SchemaExtractorService.class);
+        mockSchemaService = mock(MockSchemaService.class);
+        projectRepository = mock(ProjectRepository.class);
+
+        importService = new OpenApiImportServiceImpl(
+                parserService,
+                validatorService,
+                extractorService,
+                mockSchemaService,
+                projectRepository
+        );
+
+        userId = UUID.randomUUID();
+        projectId = UUID.randomUUID();
+
+        project = new Project();
+        project.setId(projectId);
+    }
+
+    /**
+     * Helper:
+     * Build valid multipart YAML file
+     */
+    private MultipartFile buildValidFile() {
+
+        return new MockMultipartFile(
+                "file",
+                "openapi.yaml",
+                "application/x-yaml",
+                "openapi: 3.0.3".getBytes()
+        );
+    }
+
+    /**
+     * Helper:
+     * Build parsed spec
+     */
+    private ParsedOpenApiSpec buildParsedSpec() {
+
+        Map<String, Schema> schemas =
+                new LinkedHashMap<>();
+
+        ObjectSchema userSchema =
+                new ObjectSchema();
+
+        userSchema.setProperties(
+                Map.of(
+                        "id",
+                        new StringSchema()
+                )
+        );
+
+        ObjectSchema productSchema =
+                new ObjectSchema();
+
+        productSchema.setProperties(
+                Map.of(
+                        "name",
+                        new StringSchema()
+                )
+        );
+
+        schemas.put("User", userSchema);
+        schemas.put("Product", productSchema);
+
+        return new ParsedOpenApiSpec(
+                "3.0.3",
+                schemas
+        );
+    }
+
+
+    @Nested
+    @DisplayName("Successful Import Tests")
+    class SuccessfulImportTests {
+
+        @Test
+        @DisplayName("Should import all schemas successfully")
+        void shouldImportAllSchemasSuccessfully() {
+
+            MultipartFile file = buildValidFile();
+            ParsedOpenApiSpec parsedSpec = buildParsedSpec();
+
+            when(projectRepository.findById(projectId))
+                    .thenReturn(Optional.of(project));
+
+            when(parserService.parse(file))
+                    .thenReturn(parsedSpec);
+
+            when(extractorService.extractSchema(anyString(), any()))
+                    .thenAnswer(invocation -> {
+                        String name = invocation.getArgument(0);
+
+                        return Map.of(
+                                "field",
+                                "string"
+                        );
+                    });
+
+            when(mockSchemaService.createSchema(
+                    eq(userId),
+                    eq(projectId),
+                    any(CreateMockSchemaRequest.class)
+            )).thenAnswer(invocation -> {
+
+                CreateMockSchemaRequest req =
+                        invocation.getArgument(2);
+
+                MockSchemaResponse response =
+                        new MockSchemaResponse();
+
+                response.setName(req.getName());
+
+                return response;
+            });
+
+            OpenApiImportResponse response =
+                    importService.importOpenApi(
+                            userId,
+                            projectId,
+                            file
+                    );
+
+            assertNotNull(response);
+
+            assertEquals(
+                    2,
+                    response.getTotalImported()
+            );
+
+            assertEquals(
+                    0,
+                    response.getTotalSkipped()
+            );
+
+            verify(parserService).parse(file);
+            verify(validatorService).validate(parsedSpec);
+
+            verify(mockSchemaService, times(2))
+                    .createSchema(
+                            eq(userId),
+                            eq(projectId),
+                            any(CreateMockSchemaRequest.class)
+                    );
+        }
+
+
+        @Test
+        @DisplayName("Should build correct schema creation request")
+        void shouldBuildCorrectSchemaCreationRequest() {
+
+            MultipartFile file = buildValidFile();
+            ParsedOpenApiSpec parsedSpec = buildParsedSpec();
+
+            when(projectRepository.findById(projectId))
+                    .thenReturn(Optional.of(project));
+
+            when(parserService.parse(file))
+                    .thenReturn(parsedSpec);
+
+            when(extractorService.extractSchema(anyString(), any()))
+                    .thenReturn(
+                            Map.of(
+                                    "id",
+                                    "uuid"
+                            )
+                    );
+
+            when(mockSchemaService.createSchema(
+                    any(),
+                    any(),
+                    any()
+            )).thenReturn(
+                    new MockSchemaResponse()
+            );
+
+            importService.importOpenApi(
+                    userId,
+                    projectId,
+                    file
+            );
+
+            ArgumentCaptor<CreateMockSchemaRequest> captor =
+                    ArgumentCaptor.forClass(
+                            CreateMockSchemaRequest.class
+                    );
+
+            verify(mockSchemaService, atLeastOnce())
+                    .createSchema(
+                            eq(userId),
+                            eq(projectId),
+                            captor.capture()
+                    );
+
+            CreateMockSchemaRequest request =
+                    captor.getValue();
+
+            assertNotNull(request.getName());
+            assertNotNull(request.getSchemaJson());
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Partial Failure Tests")
+    class PartialFailureTests {
+
+        @Test
+        @DisplayName("Should skip failed schemas and continue importing")
+        void shouldSkipFailedSchemasAndContinue() {
+
+            MultipartFile file = buildValidFile();
+            ParsedOpenApiSpec parsedSpec = buildParsedSpec();
+
+            when(projectRepository.findById(projectId))
+                    .thenReturn(Optional.of(project));
+
+            when(parserService.parse(file))
+                    .thenReturn(parsedSpec);
+
+            when(extractorService.extractSchema(
+                    eq("User"),
+                    any()
+            )).thenThrow(
+                    new BadRequestException("Invalid User schema")
+            );
+
+            when(extractorService.extractSchema(
+                    eq("Product"),
+                    any()
+            )).thenReturn(
+                    Map.of(
+                            "name",
+                            "string"
+                    )
+            );
+
+            when(mockSchemaService.createSchema(
+                    any(),
+                    any(),
+                    any()
+            )).thenReturn(
+                    new MockSchemaResponse()
+            );
+
+            OpenApiImportResponse response =
+                    importService.importOpenApi(
+                            userId,
+                            projectId,
+                            file
+                    );
+
+            assertEquals(
+                    1,
+                    response.getTotalImported()
+            );
+
+            assertEquals(
+                    1,
+                    response.getTotalSkipped()
+            );
+
+            assertEquals(
+                    "User",
+                    response.getSkipped()
+                            .getFirst()
+                            .component()
+            );
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Failure Tests")
+    class FailureTests {
+
+        @Test
+        @DisplayName("Should reject missing project")
+        void shouldRejectMissingProject() {
+
+            MultipartFile file = buildValidFile();
+
+            when(projectRepository.findById(projectId))
+                    .thenReturn(Optional.empty());
+
+            ResourceNotFoundException ex =
+                    assertThrows(
+                            ResourceNotFoundException.class,
+                            () -> importService.importOpenApi(
+                                    userId,
+                                    projectId,
+                                    file
+                            )
+                    );
+
+            assertEquals(
+                    "Project not found",
+                    ex.getMessage()
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject null file")
+        void shouldRejectNullFile() {
+
+            when(projectRepository.findById(projectId))
+                    .thenReturn(Optional.of(project));
+
+            BadRequestException ex =
+                    assertThrows(
+                            BadRequestException.class,
+                            () -> importService.importOpenApi(
+                                    userId,
+                                    projectId,
+                                    null
+                            )
+                    );
+
+            assertEquals(
+                    "OpenAPI file is required",
+                    ex.getMessage()
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject unsupported file type")
+        void shouldRejectUnsupportedFileType() {
+
+            MultipartFile file =
+                    new MockMultipartFile(
+                            "file",
+                            "invalid.txt",
+                            "text/plain",
+                            "bad".getBytes()
+                    );
+
+            when(projectRepository.findById(projectId))
+                    .thenReturn(Optional.of(project));
+
+            BadRequestException ex =
+                    assertThrows(
+                            BadRequestException.class,
+                            () -> importService.importOpenApi(
+                                    userId,
+                                    projectId,
+                                    file
+                            )
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "Unsupported file type"
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject oversized file")
+        void shouldRejectOversizedFile() {
+
+            byte[] oversized =
+                    new byte[(2 * 1024 * 1024) + 1];
+
+            MultipartFile file =
+                    new MockMultipartFile(
+                            "file",
+                            "large.yaml",
+                            "application/x-yaml",
+                            oversized
+                    );
+
+            when(projectRepository.findById(projectId))
+                    .thenReturn(Optional.of(project));
+
+            BadRequestException ex =
+                    assertThrows(
+                            BadRequestException.class,
+                            () -> importService.importOpenApi(
+                                    userId,
+                                    projectId,
+                                    file
+                            )
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "File size exceeds"
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should propagate parser failure")
+        void shouldPropagateParserFailure() {
+
+            MultipartFile file = buildValidFile();
+
+            when(projectRepository.findById(projectId))
+                    .thenReturn(Optional.of(project));
+
+            when(parserService.parse(file))
+                    .thenThrow(
+                            new InvalidOpenApiException(
+                                    "Invalid spec"
+                            )
+                    );
+
+            InvalidOpenApiException ex =
+                    assertThrows(
+                            InvalidOpenApiException.class,
+                            () -> importService.importOpenApi(
+                                    userId,
+                                    projectId,
+                                    file
+                            )
+                    );
+
+            assertEquals(
+                    "Invalid spec",
+                    ex.getMessage()
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should propagate validator failure")
+        void shouldPropagateValidatorFailure() {
+
+            MultipartFile file = buildValidFile();
+            ParsedOpenApiSpec parsedSpec = buildParsedSpec();
+
+            when(projectRepository.findById(projectId))
+                    .thenReturn(Optional.of(project));
+
+            when(parserService.parse(file))
+                    .thenReturn(parsedSpec);
+
+            doThrow(
+                    new InvalidOpenApiException(
+                            "Validation failed"
+                    )
+            ).when(validatorService)
+                    .validate(parsedSpec);
+
+            InvalidOpenApiException ex =
+                    assertThrows(
+                            InvalidOpenApiException.class,
+                            () -> importService.importOpenApi(
+                                    userId,
+                                    projectId,
+                                    file
+                            )
+                    );
+
+            assertEquals(
+                    "Validation failed",
+                    ex.getMessage()
+            );
+        }
+    }
+}

--- a/src/test/java/com/mockify/backend/service/open_api_import/OpenApiParserServiceTest.java
+++ b/src/test/java/com/mockify/backend/service/open_api_import/OpenApiParserServiceTest.java
@@ -1,0 +1,381 @@
+package com.mockify.backend.service.open_api_import;
+
+import com.mockify.backend.dto.internal.ParsedOpenApiSpec;
+import com.mockify.backend.exception.InvalidOpenApiException;
+import com.mockify.backend.service.OpenApiParserService;
+import com.mockify.backend.service.impl.OpenApiParserServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+import java.io.InputStream;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * OpenApiParserServiceTest
+ *
+ * Purpose:
+ * - Verify OpenAPI 3.x parsing
+ * - Verify Swagger 2.0 parsing compatibility
+ * - Verify schema extraction quality
+ * - Verify invalid file rejection
+ * - Verify defensive parser validation
+ *
+ * Test Resources:
+ * src/test/resources/openApi-import-files/
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class OpenApiParserServiceTest {
+
+    private OpenApiParserService parserService;
+
+    private static final String RESOURCE_PATH =
+            "/openApi-import-files/";
+
+    @BeforeEach
+    void setUp() {
+        parserService = new OpenApiParserServiceImpl();
+    }
+
+    /**
+     * Utility:
+     * Load test resource file as MultipartFile
+     */
+    private MultipartFile loadFile(
+            String filename,
+            String contentType
+    ) throws IOException {
+
+        InputStream inputStream =
+                getClass().getResourceAsStream(
+                        RESOURCE_PATH + filename
+                );
+
+        assertNotNull(
+                inputStream,
+                "Test file not found: " + filename
+        );
+
+        return new MockMultipartFile(
+                "file",
+                filename,
+                contentType,
+                inputStream.readAllBytes()
+        );
+    }
+
+
+    @Nested
+    @DisplayName("Successful Parsing Tests")
+    class SuccessfulParsingTests {
+
+        @Test
+        @DisplayName("Should parse basic valid OpenAPI YAML successfully")
+        void shouldParseBasicValidYamlSuccessfully()
+                throws Exception {
+
+            MultipartFile file = loadFile(
+                    "basic-valid.yaml",
+                    "application/x-yaml"
+            );
+
+            ParsedOpenApiSpec result =
+                    parserService.parse(file);
+
+            assertNotNull(result);
+
+            assertEquals(
+                    "3.0.3",
+                    result.getVersion()
+            );
+
+            assertNotNull(result.getSchemas());
+
+            assertFalse(result.getSchemas().isEmpty());
+        }
+
+
+        @Test
+        @DisplayName("Should parse enterprise large OpenAPI YAML successfully")
+        void shouldParseEnterpriseLargeYamlSuccessfully()
+                throws Exception {
+
+            MultipartFile file = loadFile(
+                    "enterprise-large.yaml",
+                    "application/x-yaml"
+            );
+
+            ParsedOpenApiSpec result =
+                    parserService.parse(file);
+
+            assertNotNull(result);
+
+            assertEquals(
+                    "3.0.3",
+                    result.getVersion()
+            );
+
+            /*
+             * Enterprise spec should contain
+             * multiple reusable schemas
+             */
+            assertTrue(
+                    result.getSchemas().size() >= 2
+            );
+        }
+
+        @Test
+        @DisplayName("Should parse Swagger 2.0 specification successfully")
+        void shouldParseSwagger2Successfully()
+                throws Exception {
+
+            MultipartFile file = loadFile(
+                    "swagger-2.0.yaml",
+                    "application/x-yaml"
+            );
+
+            ParsedOpenApiSpec result =
+                    parserService.parse(file);
+
+            assertNotNull(result);
+
+            // swagger-parser converted Swagger 2.0 into internal OpenAPI 3.0.1 representation
+            assertEquals(
+                    "3.0.1",
+                    result.getVersion()
+            );
+
+            assertNotNull(result.getSchemas());
+
+            assertFalse(result.getSchemas().isEmpty());
+
+            assertTrue(result.getSchemas().containsKey("User"));
+
+            assertTrue(result.getSchemas().containsKey("Post"));
+        }
+
+        @Test
+        @DisplayName("Should extract expected schema names")
+        void shouldExtractExpectedSchemaNames()
+                throws Exception {
+
+            MultipartFile file = loadFile(
+                    "basic-valid.yaml",
+                    "application/x-yaml"
+            );
+
+            ParsedOpenApiSpec result =
+                    parserService.parse(file);
+
+            assertTrue(
+                    result.getSchemas().containsKey("BlogPost")
+            );
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Failure Parsing Tests")
+    class FailureParsingTests {
+
+        @Test
+        @DisplayName("Should throw exception when file is null")
+        void shouldThrowWhenFileIsNull() {
+
+            InvalidOpenApiException ex =
+                    assertThrows(
+                            InvalidOpenApiException.class,
+                            () -> parserService.parse(null)
+                    );
+
+            assertEquals(
+                    "Uploaded OpenAPI file is empty",
+                    ex.getMessage()
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should throw exception when file is empty")
+        void shouldThrowWhenFileIsEmpty() {
+
+            MultipartFile emptyFile =
+                    new MockMultipartFile(
+                            "file",
+                            "empty.yaml",
+                            "application/x-yaml",
+                            new byte[0]
+                    );
+
+            InvalidOpenApiException ex =
+                    assertThrows(
+                            InvalidOpenApiException.class,
+                            () -> parserService.parse(emptyFile)
+                    );
+
+            assertEquals(
+                    "Uploaded OpenAPI file is empty",
+                    ex.getMessage()
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should throw exception for broken YAML")
+        void shouldThrowForBrokenYaml()
+                throws Exception {
+
+            MultipartFile file = loadFile(
+                    "invalid-broken.yaml",
+                    "application/x-yaml"
+            );
+
+            InvalidOpenApiException ex =
+                    assertThrows(
+                            InvalidOpenApiException.class,
+                            () -> parserService.parse(file)
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "Invalid OpenAPI specification"
+                    ) ||
+                            ex.getMessage().contains(
+                                    "Failed to parse OpenAPI specification"
+                            )
+            );
+        }
+
+        @Test
+        @DisplayName("Should throw exception when no schemas exist")
+        void shouldThrowWhenSchemasMissing()
+                throws Exception {
+
+            String yaml = """
+                    openapi: 3.0.3
+                    info:
+                      title: Empty API
+                      version: 1.0.0
+                    paths: {}
+                    """;
+
+            MultipartFile file =
+                    new MockMultipartFile(
+                            "file",
+                            "empty-spec.yaml",
+                            "application/x-yaml",
+                            yaml.getBytes()
+                    );
+
+            ParsedOpenApiSpec result =
+                    parserService.parse(file);
+
+            /*
+             * Parser itself succeeds,
+             * validator later rejects missing schemas
+             */
+            assertNotNull(result);
+
+            assertTrue(
+                    result.getSchemas().isEmpty()
+            );
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Schema Extraction Quality Tests")
+    class SchemaExtractionQualityTests {
+
+        @Test
+        @DisplayName("Should preserve nested schemas")
+        void shouldPreserveNestedSchemas()
+                throws Exception {
+
+            MultipartFile file = loadFile(
+                    "enterprise-large.yaml",
+                    "application/x-yaml"
+            );
+
+            ParsedOpenApiSpec result =
+                    parserService.parse(file);
+
+            assertNotNull(
+                    result.getSchemas()
+                            .get("User")
+                            .getProperties()
+                            .get("profile")
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should preserve array schemas")
+        void shouldPreserveArraySchemas()
+                throws Exception {
+
+            MultipartFile file = loadFile(
+                    "enterprise-large.yaml",
+                    "application/x-yaml"
+            );
+
+            ParsedOpenApiSpec result =
+                    parserService.parse(file);
+
+            assertNotNull(
+                    result.getSchemas()
+                            .get("User")
+                            .getProperties()
+                            .get("addresses")
+            );
+        }
+
+        @Test
+        @DisplayName("Should preserve Swagger 2 nested object schemas")
+        void shouldPreserveSwagger2NestedSchemas()
+                throws Exception {
+
+            MultipartFile file = loadFile(
+                    "swagger-2.0.yaml",
+                    "application/x-yaml"
+            );
+
+            ParsedOpenApiSpec result =
+                    parserService.parse(file);
+
+            assertNotNull(
+                    result.getSchemas()
+                            .get("User")
+                            .getProperties()
+                            .get("profile")
+            );
+        }
+
+        @Test
+        @DisplayName("Should preserve Swagger 2 array schemas")
+        void shouldPreserveSwagger2ArraySchemas()
+                throws Exception {
+
+            MultipartFile file = loadFile(
+                    "swagger-2.0.yaml",
+                    "application/x-yaml"
+            );
+
+            ParsedOpenApiSpec result =
+                    parserService.parse(file);
+
+            assertNotNull(
+                    result.getSchemas()
+                            .get("Post")
+                            .getProperties()
+                            .get("comments")
+            );
+        }
+    }
+}

--- a/src/test/java/com/mockify/backend/service/open_api_import/OpenApiValidatorServiceTest.java
+++ b/src/test/java/com/mockify/backend/service/open_api_import/OpenApiValidatorServiceTest.java
@@ -1,0 +1,453 @@
+package com.mockify.backend.service.open_api_import;
+
+import com.mockify.backend.dto.internal.ParsedOpenApiSpec;
+import com.mockify.backend.exception.InvalidOpenApiException;
+import com.mockify.backend.service.OpenApiValidatorService;
+import com.mockify.backend.service.impl.OpenApiValidatorServiceImpl;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.BooleanSchema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * OpenApiValidatorServiceTest
+ *
+ * Purpose:
+ * - Validate OpenAPI spec business rules
+ * - Ensure schema structure correctness
+ * - Catch invalid component definitions
+ * - Ensure supported type enforcement
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class OpenApiValidatorServiceTest {
+
+    private OpenApiValidatorService validatorService;
+
+    @BeforeEach
+    void setUp() {
+        validatorService = new OpenApiValidatorServiceImpl();
+    }
+
+    /**
+     * Helper:
+     * Build valid ParsedOpenApiSpec quickly
+     */
+    private ParsedOpenApiSpec buildValidSpec() {
+
+        Map<String, Schema> schemas = new LinkedHashMap<>();
+
+        ObjectSchema userSchema = new ObjectSchema();
+
+        Map<String, Schema> properties = new LinkedHashMap<>();
+        properties.put("id", new StringSchema().format("uuid"));
+        properties.put("name", new StringSchema());
+        properties.put("email", new StringSchema().format("email"));
+        properties.put("active", new BooleanSchema());
+
+        userSchema.setProperties(properties);
+
+        schemas.put("User", userSchema);
+
+        return new ParsedOpenApiSpec(
+                "3.0.3",
+                schemas
+        );
+    }
+
+
+    @Nested
+    @DisplayName("Successful Validation Tests")
+    class SuccessfulValidationTests {
+
+        @Test
+        @DisplayName("Should validate correct OpenAPI 3.x spec")
+        void shouldValidateCorrectSpec() {
+
+            ParsedOpenApiSpec spec = buildValidSpec();
+
+            assertDoesNotThrow(
+                    () -> validatorService.validate(spec)
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should validate nested object schema")
+        void shouldValidateNestedObjectSchema() {
+
+            ObjectSchema nestedObject = new ObjectSchema();
+
+            Map<String, Schema> nestedProps = new LinkedHashMap<>();
+            nestedProps.put("age", new IntegerSchema());
+            nestedProps.put("gender", new StringSchema());
+
+            nestedObject.setProperties(nestedProps);
+
+            ObjectSchema userSchema = new ObjectSchema();
+
+            Map<String, Schema> properties = new LinkedHashMap<>();
+            properties.put("profile", nestedObject);
+
+            userSchema.setProperties(properties);
+
+            Map<String, Schema> schemas = new LinkedHashMap<>();
+            schemas.put("User", userSchema);
+
+            ParsedOpenApiSpec spec =
+                    new ParsedOpenApiSpec("3.0.3", schemas);
+
+            assertDoesNotThrow(
+                    () -> validatorService.validate(spec)
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should validate array property")
+        void shouldValidateArrayProperty() {
+
+            ArraySchema tags = new ArraySchema();
+            tags.setItems(new StringSchema());
+
+            ObjectSchema productSchema = new ObjectSchema();
+
+            Map<String, Schema> properties = new LinkedHashMap<>();
+            properties.put("tags", tags);
+
+            productSchema.setProperties(properties);
+
+            Map<String, Schema> schemas = new LinkedHashMap<>();
+            schemas.put("Product", productSchema);
+
+            ParsedOpenApiSpec spec =
+                    new ParsedOpenApiSpec("3.0.3", schemas);
+
+            assertDoesNotThrow(
+                    () -> validatorService.validate(spec)
+            );
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Version Validation Failure Tests")
+    class VersionValidationFailureTests {
+
+        @Test
+        @DisplayName("Should reject null spec")
+        void shouldRejectNullSpec() {
+
+            InvalidOpenApiException ex =
+                    assertThrows(
+                            InvalidOpenApiException.class,
+                            () -> validatorService.validate(null)
+                    );
+
+            assertEquals(
+                    "Parsed OpenAPI specification is null",
+                    ex.getMessage()
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject missing version")
+        void shouldRejectMissingVersion() {
+
+            ParsedOpenApiSpec spec =
+                    new ParsedOpenApiSpec(
+                            null,
+                            new LinkedHashMap<>()
+                    );
+
+            InvalidOpenApiException ex =
+                    assertThrows(
+                            InvalidOpenApiException.class,
+                            () -> validatorService.validate(spec)
+                    );
+
+            assertEquals(
+                    "Missing OpenAPI version",
+                    ex.getMessage()
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject Swagger invalid versions")
+        void shouldRejectSwagger() {
+
+            ParsedOpenApiSpec spec =
+                    new ParsedOpenApiSpec(
+                            "1.0",
+                            new LinkedHashMap<>()
+                    );
+
+            InvalidOpenApiException ex =
+                    assertThrows(
+                            InvalidOpenApiException.class,
+                            () -> validatorService.validate(spec)
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "Unsupported OpenAPI version"
+                    )
+            );
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Schema Structure Failure Tests")
+    class SchemaStructureFailureTests {
+
+        @Test
+        @DisplayName("Should reject missing schemas")
+        void shouldRejectMissingSchemas() {
+
+            ParsedOpenApiSpec spec =
+                    new ParsedOpenApiSpec(
+                            "3.0.3",
+                            new LinkedHashMap<>()
+                    );
+
+            InvalidOpenApiException ex =
+                    assertThrows(
+                            InvalidOpenApiException.class,
+                            () -> validatorService.validate(spec)
+                    );
+
+            assertEquals(
+                    "No reusable schemas found in OpenAPI components",
+                    ex.getMessage()
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject blank schema name")
+        void shouldRejectBlankSchemaName() {
+
+            Map<String, Schema> schemas =
+                    new LinkedHashMap<>();
+
+            ObjectSchema schema = new ObjectSchema();
+            schema.setProperties(
+                    Map.of("id", new StringSchema())
+            );
+
+            schemas.put("", schema);
+
+            ParsedOpenApiSpec spec =
+                    new ParsedOpenApiSpec("3.0.3", schemas);
+
+            InvalidOpenApiException ex =
+                    assertThrows(
+                            InvalidOpenApiException.class,
+                            () -> validatorService.validate(spec)
+                    );
+
+            assertEquals(
+                    "Schema name cannot be empty",
+                    ex.getMessage()
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject schema with no properties")
+        void shouldRejectSchemaWithNoProperties() {
+
+            Map<String, Schema> schemas =
+                    new LinkedHashMap<>();
+
+            ObjectSchema emptySchema =
+                    new ObjectSchema();
+
+            schemas.put("User", emptySchema);
+
+            ParsedOpenApiSpec spec =
+                    new ParsedOpenApiSpec("3.0.3", schemas);
+
+            InvalidOpenApiException ex =
+                    assertThrows(
+                            InvalidOpenApiException.class,
+                            () -> validatorService.validate(spec)
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "contains no properties"
+                    )
+            );
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Property Validation Failure Tests")
+    class PropertyValidationFailureTests {
+
+        @Test
+        @DisplayName("Should reject unsupported property type")
+        void shouldRejectUnsupportedPropertyType() {
+
+            Schema unsupported =
+                    new Schema<>().type("abc");
+
+            ObjectSchema schema =
+                    new ObjectSchema();
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put("avatar", unsupported);
+
+            schema.setProperties(properties);
+
+            Map<String, Schema> schemas =
+                    new LinkedHashMap<>();
+
+            schemas.put("User", schema);
+
+            ParsedOpenApiSpec spec =
+                    new ParsedOpenApiSpec("3.0.3", schemas);
+
+            InvalidOpenApiException ex =
+                    assertThrows(
+                            InvalidOpenApiException.class,
+                            () -> validatorService.validate(spec)
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "Unsupported property type"
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject property missing type")
+        void shouldRejectPropertyMissingType() {
+
+            Schema<?> missingType =
+                    new Schema<>();
+
+            ObjectSchema schema =
+                    new ObjectSchema();
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put("profile", missingType);
+
+            schema.setProperties(properties);
+
+            Map<String, Schema> schemas =
+                    new LinkedHashMap<>();
+
+            schemas.put("User", schema);
+
+            ParsedOpenApiSpec spec =
+                    new ParsedOpenApiSpec("3.0.3", schemas);
+
+            InvalidOpenApiException ex =
+                    assertThrows(
+                            InvalidOpenApiException.class,
+                            () -> validatorService.validate(spec)
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "missing type"
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject array without items")
+        void shouldRejectArrayWithoutItems() {
+
+            ArraySchema invalidArray =
+                    new ArraySchema();
+
+            ObjectSchema schema =
+                    new ObjectSchema();
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put("tags", invalidArray);
+
+            schema.setProperties(properties);
+
+            Map<String, Schema> schemas =
+                    new LinkedHashMap<>();
+
+            schemas.put("Product", schema);
+
+            ParsedOpenApiSpec spec =
+                    new ParsedOpenApiSpec("3.0.3", schemas);
+
+            InvalidOpenApiException ex =
+                    assertThrows(
+                            InvalidOpenApiException.class,
+                            () -> validatorService.validate(spec)
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "missing item definition"
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should allow $ref property")
+        void shouldAllowRefProperty() {
+
+            Schema<?> refSchema =
+                    new Schema<>().$ref(
+                            "#/components/schemas/User"
+                    );
+
+            ObjectSchema schema =
+                    new ObjectSchema();
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put("author", refSchema);
+
+            schema.setProperties(properties);
+
+            Map<String, Schema> schemas =
+                    new LinkedHashMap<>();
+
+            schemas.put("BlogPost", schema);
+
+            ParsedOpenApiSpec spec =
+                    new ParsedOpenApiSpec("3.0.3", schemas);
+
+            assertDoesNotThrow(
+                    () -> validatorService.validate(spec)
+            );
+        }
+    }
+}

--- a/src/test/java/com/mockify/backend/service/open_api_import/SchemaExtractorServiceTest.java
+++ b/src/test/java/com/mockify/backend/service/open_api_import/SchemaExtractorServiceTest.java
@@ -1,0 +1,481 @@
+package com.mockify.backend.service.open_api_import;
+
+import com.mockify.backend.service.SchemaExtractorService;
+import com.mockify.backend.service.impl.SchemaExtractorServiceImpl;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.BooleanSchema;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.NumberSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * SchemaExtractorServiceTest
+ *
+ * Purpose:
+ * - Verify OpenAPI → Mockify schema conversion
+ * - Validate primitive type mapping
+ * - Validate format conversions
+ * - Validate nested objects
+ * - Validate arrays
+ * - Validate refs
+ */
+
+@SpringBootTest
+@ActiveProfiles("test")
+class SchemaExtractorServiceTest {
+
+    private SchemaExtractorService extractorService;
+
+    @BeforeEach
+    void setUp() {
+        extractorService = new SchemaExtractorServiceImpl();
+    }
+
+    /**
+     * Helper:
+     * Build schema with properties
+     */
+    private ObjectSchema buildSchema(
+            Map<String, Schema> properties
+    ) {
+
+        ObjectSchema schema = new ObjectSchema();
+        schema.setProperties(properties);
+
+        return schema;
+    }
+
+
+    @Nested
+    @DisplayName("Primitive Type Extraction Tests")
+    class PrimitiveTypeExtractionTests {
+
+        @Test
+        @DisplayName("Should extract primitive fields correctly")
+        void shouldExtractPrimitiveFieldsCorrectly() {
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put("name", new StringSchema());
+            properties.put("age", new IntegerSchema());
+            properties.put("price", new NumberSchema());
+            properties.put("active", new BooleanSchema());
+
+            Map<String, Object> result =
+                    extractorService.extractSchema(
+                            "User",
+                            buildSchema(properties)
+                    );
+
+            assertEquals("string", result.get("name"));
+            assertEquals("number", result.get("age"));
+            assertEquals("number", result.get("price"));
+            assertEquals("boolean", result.get("active"));
+        }
+    }
+
+
+    @Nested
+    @DisplayName("String Format Mapping Tests")
+    class StringFormatMappingTests {
+
+        @Test
+        @DisplayName("Should map UUID format correctly")
+        void shouldMapUuidCorrectly() {
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put(
+                    "id",
+                    new StringSchema().format("uuid")
+            );
+
+            Map<String, Object> result =
+                    extractorService.extractSchema(
+                            "User",
+                            buildSchema(properties)
+                    );
+
+            assertEquals(
+                    "uuid",
+                    result.get("id")
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should map email format correctly")
+        void shouldMapEmailCorrectly() {
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put(
+                    "email",
+                    new StringSchema().format("email")
+            );
+
+            Map<String, Object> result =
+                    extractorService.extractSchema(
+                            "User",
+                            buildSchema(properties)
+                    );
+
+            assertEquals(
+                    "email",
+                    result.get("email")
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should map datetime format correctly")
+        void shouldMapDateTimeCorrectly() {
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put(
+                    "createdAt",
+                    new StringSchema().format("date-time")
+            );
+
+            Map<String, Object> result =
+                    extractorService.extractSchema(
+                            "User",
+                            buildSchema(properties)
+                    );
+
+            assertEquals(
+                    "datetime",
+                    result.get("createdAt")
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should map URL format correctly")
+        void shouldMapUrlCorrectly() {
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put(
+                    "avatarUrl",
+                    new StringSchema().format("uri")
+            );
+
+            Map<String, Object> result =
+                    extractorService.extractSchema(
+                            "User",
+                            buildSchema(properties)
+                    );
+
+            assertEquals(
+                    "url",
+                    result.get("avatarUrl")
+            );
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Nested Object Extraction Tests")
+    class NestedObjectExtractionTests {
+
+        @Test
+        @DisplayName("Should extract nested object correctly")
+        void shouldExtractNestedObjectCorrectly() {
+
+            ObjectSchema profileSchema =
+                    new ObjectSchema();
+
+            Map<String, Schema> nestedProps =
+                    new LinkedHashMap<>();
+
+            nestedProps.put("age", new IntegerSchema());
+            nestedProps.put("gender", new StringSchema());
+
+            profileSchema.setProperties(nestedProps);
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put("profile", profileSchema);
+
+            Map<String, Object> result =
+                    extractorService.extractSchema(
+                            "User",
+                            buildSchema(properties)
+                    );
+
+            assertTrue(
+                    result.get("profile") instanceof Map
+            );
+
+            Map<?, ?> profile =
+                    (Map<?, ?>) result.get("profile");
+
+            assertEquals(
+                    "number",
+                    profile.get("age")
+            );
+
+            assertEquals(
+                    "string",
+                    profile.get("gender")
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should fallback empty object correctly")
+        void shouldFallbackEmptyObjectCorrectly() {
+
+            ObjectSchema emptyObject =
+                    new ObjectSchema();
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put("metadata", emptyObject);
+
+            Map<String, Object> result =
+                    extractorService.extractSchema(
+                            "User",
+                            buildSchema(properties)
+                    );
+
+            assertTrue(
+                    result.get("metadata") instanceof Map
+            );
+
+            Map<?, ?> metadata =
+                    (Map<?, ?>) result.get("metadata");
+
+            assertEquals(
+                    "object",
+                    metadata.get("type")
+            );
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Array Extraction Tests")
+    class ArrayExtractionTests {
+
+        @Test
+        @DisplayName("Should extract primitive array correctly")
+        void shouldExtractPrimitiveArrayCorrectly() {
+
+            ArraySchema tags =
+                    new ArraySchema();
+
+            tags.setItems(new StringSchema());
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put("tags", tags);
+
+            Map<String, Object> result =
+                    extractorService.extractSchema(
+                            "Product",
+                            buildSchema(properties)
+                    );
+
+            assertTrue(
+                    result.get("tags") instanceof Map
+            );
+
+            Map<?, ?> array =
+                    (Map<?, ?>) result.get("tags");
+
+            assertEquals(
+                    "array",
+                    array.get("type")
+            );
+
+            assertEquals(
+                    "string",
+                    array.get("items")
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should extract object array correctly")
+        void shouldExtractObjectArrayCorrectly() {
+
+            ObjectSchema address =
+                    new ObjectSchema();
+
+            Map<String, Schema> addressProps =
+                    new LinkedHashMap<>();
+
+            addressProps.put("city", new StringSchema());
+            addressProps.put("zipCode", new StringSchema());
+
+            address.setProperties(addressProps);
+
+            ArraySchema addresses =
+                    new ArraySchema();
+
+            addresses.setItems(address);
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put("addresses", addresses);
+
+            Map<String, Object> result =
+                    extractorService.extractSchema(
+                            "User",
+                            buildSchema(properties)
+                    );
+
+            Map<?, ?> array =
+                    (Map<?, ?>) result.get("addresses");
+
+            assertEquals(
+                    "array",
+                    array.get("type")
+            );
+
+            assertTrue(
+                    array.get("items") instanceof Map
+            );
+
+            Map<?, ?> nestedItems =
+                    (Map<?, ?>) array.get("items");
+
+            assertEquals(
+                    "string",
+                    nestedItems.get("city")
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should fallback missing array items to string")
+        void shouldFallbackMissingArrayItemsToString() {
+
+            ArraySchema array =
+                    new ArraySchema();
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put("tags", array);
+
+            Map<String, Object> result =
+                    extractorService.extractSchema(
+                            "Product",
+                            buildSchema(properties)
+                    );
+
+            Map<?, ?> extracted =
+                    (Map<?, ?>) result.get("tags");
+
+            assertEquals(
+                    "string",
+                    extracted.get("items")
+            );
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Reference Extraction Tests")
+    class ReferenceExtractionTests {
+
+        @Test
+        @DisplayName("Should treat $ref as object")
+        void shouldTreatRefAsObject() {
+
+            Schema<?> refSchema =
+                    new Schema<>()
+                            .$ref("#/components/schemas/User");
+
+            Map<String, Schema> properties =
+                    new LinkedHashMap<>();
+
+            properties.put("author", refSchema);
+
+            Map<String, Object> result =
+                    extractorService.extractSchema(
+                            "BlogPost",
+                            buildSchema(properties)
+                    );
+
+            assertEquals(
+                    "object",
+                    result.get("author")
+            );
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Failure Tests")
+    class FailureTests {
+
+        @Test
+        @DisplayName("Should reject null schema")
+        void shouldRejectNullSchema() {
+
+            IllegalArgumentException ex =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> extractorService.extractSchema(
+                                    "User",
+                                    null
+                            )
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "contains no extractable properties"
+                    )
+            );
+        }
+
+
+        @Test
+        @DisplayName("Should reject schema without properties")
+        void shouldRejectSchemaWithoutProperties() {
+
+            ObjectSchema empty =
+                    new ObjectSchema();
+
+            IllegalArgumentException ex =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> extractorService.extractSchema(
+                                    "User",
+                                    empty
+                            )
+                    );
+
+            assertTrue(
+                    ex.getMessage().contains(
+                            "contains no extractable properties"
+                    )
+            );
+        }
+    }
+}

--- a/src/test/resources/openApi-import-files/basic-valid.yaml
+++ b/src/test/resources/openApi-import-files/basic-valid.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.3
+info:
+  title: Basic Valid API
+  version: 1.0.0
+  description: Simple OpenAPI specification for testing Mockify import functionality
+
+paths:
+  /posts:
+    get:
+      summary: Get all blog posts
+      responses:
+        '200':
+          description: Successful response
+
+components:
+  schemas:
+    BlogPost:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        content:
+          type: string
+        authorEmail:
+          type: string
+          format: email
+        published:
+          type: boolean
+        publishedAt:
+          type: string
+          format: date-time

--- a/src/test/resources/openApi-import-files/enterprise-large.yaml
+++ b/src/test/resources/openApi-import-files/enterprise-large.yaml
@@ -1,0 +1,305 @@
+openapi: 3.0.3
+info:
+  title: Enterprise E-Commerce API
+  version: 2.0.0
+  description: Large enterprise-grade OpenAPI specification for testing Mockify advanced schema import
+
+paths:
+  /users:
+    get:
+      summary: Get all users
+      responses:
+        '200':
+          description: Successful response
+
+  /products:
+    get:
+      summary: Get all products
+      responses:
+        '200':
+          description: Successful response
+
+  /orders:
+    get:
+      summary: Get all orders
+      responses:
+        '200':
+          description: Successful response
+
+  /payments:
+    get:
+      summary: Get all payments
+      responses:
+        '200':
+          description: Successful response
+
+components:
+  schemas:
+
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+          format: email
+        phone:
+          type: string
+        isActive:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        profile:
+          type: object
+          properties:
+            age:
+              type: integer
+            gender:
+              type: string
+            avatarUrl:
+              type: string
+              format: uri
+        addresses:
+          type: array
+          items:
+            type: object
+            properties:
+              street:
+                type: string
+              city:
+                type: string
+              state:
+                type: string
+              zipCode:
+                type: string
+              country:
+                type: string
+
+    Product:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        sku:
+          type: string
+        price:
+          type: number
+        stock:
+          type: integer
+        isAvailable:
+          type: boolean
+        category:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            name:
+              type: string
+        tags:
+          type: array
+          items:
+            type: string
+        dimensions:
+          type: object
+          properties:
+            width:
+              type: number
+            height:
+              type: number
+            depth:
+              type: number
+        createdAt:
+          type: string
+          format: date-time
+
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        userId:
+          type: string
+          format: uuid
+        orderNumber:
+          type: string
+        status:
+          type: string
+        totalAmount:
+          type: number
+        currency:
+          type: string
+        items:
+          type: array
+          items:
+            type: object
+            properties:
+              productId:
+                type: string
+                format: uuid
+              quantity:
+                type: integer
+              unitPrice:
+                type: number
+              subtotal:
+                type: number
+        shippingAddress:
+          type: object
+          properties:
+            street:
+              type: string
+            city:
+              type: string
+            state:
+              type: string
+            zipCode:
+              type: string
+            country:
+              type: string
+        billingAddress:
+          type: object
+          properties:
+            street:
+              type: string
+            city:
+              type: string
+            state:
+              type: string
+            zipCode:
+              type: string
+            country:
+              type: string
+        placedAt:
+          type: string
+          format: date-time
+
+    Payment:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        orderId:
+          type: string
+          format: uuid
+        transactionId:
+          type: string
+        method:
+          type: string
+        status:
+          type: string
+        amount:
+          type: number
+        currency:
+          type: string
+        paidAt:
+          type: string
+          format: date-time
+        cardDetails:
+          type: object
+          properties:
+            cardHolderName:
+              type: string
+            last4:
+              type: string
+            expiryMonth:
+              type: integer
+            expiryYear:
+              type: integer
+
+    Inventory:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        productId:
+          type: string
+          format: uuid
+        warehouseLocation:
+          type: string
+        quantityAvailable:
+          type: integer
+        quantityReserved:
+          type: integer
+        reorderLevel:
+          type: integer
+        updatedAt:
+          type: string
+          format: date-time
+
+    Review:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        productId:
+          type: string
+          format: uuid
+        userId:
+          type: string
+          format: uuid
+        rating:
+          type: integer
+        comment:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    Coupon:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+        discountType:
+          type: string
+        discountValue:
+          type: number
+        isActive:
+          type: boolean
+        validFrom:
+          type: string
+          format: date-time
+        validUntil:
+          type: string
+          format: date-time
+
+    Shipment:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        orderId:
+          type: string
+          format: uuid
+        carrier:
+          type: string
+        trackingNumber:
+          type: string
+        shippedAt:
+          type: string
+          format: date-time
+        deliveredAt:
+          type: string
+          format: date-time
+        shippingStatus:
+          type: string

--- a/src/test/resources/openApi-import-files/invalid-broken.yaml
+++ b/src/test/resources/openApi-import-files/invalid-broken.yaml
@@ -1,0 +1,83 @@
+openapi: 3.0.3
+info:
+  title: Invalid Broken API
+  version: 1.0.0
+  description: This file intentionally contains syntax and structural errors for testing Mockify validation
+
+servers:
+  - url: https://invalid-api.mockify.com
+
+paths:
+  /users:
+    get:
+      summary: Get all users
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items
+                $ref: '#/components/schemas/User'   # ERROR: Missing colon after 'items'
+
+  /products
+  post:                                          # ERROR: Missing colon after /products
+    summary: Create product
+    requestBody:
+      required true                              # ERROR: Missing colon
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ProductInput'
+    responses:
+      '201':
+        description Product created              # ERROR: Missing colon
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Product'
+
+components:
+  schemas:
+    User:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        email
+        type: string                            # ERROR: Missing colon after email
+
+    Product:
+      type: object
+      required:
+        - id
+        - name
+        - price
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        price:
+          type: number
+          format: float
+
+    ProductInput:
+      type: object
+      required:
+        - name
+        - price
+      properties:
+        name:
+          type: string
+        price:
+          type: number
+
+security:
+  - bearerAuth                                   # ERROR: Invalid security format

--- a/src/test/resources/openApi-import-files/invalid-file.txt
+++ b/src/test/resources/openApi-import-files/invalid-file.txt
@@ -1,0 +1,12 @@
+This is not a valid OpenAPI specification file.
+
+Mockify should reject this file because:
+- Unsupported file extension (.txt)
+- Not YAML or JSON
+- No OpenAPI or Swagger structure
+- Invalid parser input
+
+Expected Result:
+{
+  "error": "Unsupported file type. Please upload .yaml, .yml, or .json files only."
+}

--- a/src/test/resources/openApi-import-files/swagger-2.0.yaml
+++ b/src/test/resources/openApi-import-files/swagger-2.0.yaml
@@ -1,0 +1,195 @@
+swagger: "2.0"
+info:
+  title: Swagger 2.0 Compatibility Test API
+  version: "1.0.0"
+  description: Swagger 2.0 specification for testing backward compatibility in Mockify OpenAPI import
+
+host: api.example.com
+basePath: /v1
+schemes:
+  - https
+
+consumes:
+  - application/json
+produces:
+  - application/json
+
+paths:
+  /users:
+    get:
+      summary: Get all users
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/User"
+
+    post:
+      summary: Create a new user
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: "#/definitions/User"
+      responses:
+        201:
+          description: User created successfully
+
+  /posts:
+    get:
+      summary: Get all posts
+      responses:
+        200:
+          description: Successful response
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Post"
+
+    post:
+      summary: Create a new post
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: "#/definitions/Post"
+      responses:
+        201:
+          description: Post created successfully
+
+definitions:
+
+  User:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+      username:
+        type: string
+      email:
+        type: string
+        format: email
+      fullName:
+        type: string
+      bio:
+        type: string
+      profile:
+        type: object
+        properties:
+          age:
+            type: integer
+          gender:
+            type: string
+          avatar:
+            type: object
+            properties:
+              url:
+                type: string
+                format: uri
+              thumbnailUrl:
+                type: string
+                format: uri
+          socialLinks:
+            type: object
+            properties:
+              website:
+                type: string
+                format: uri
+              twitter:
+                type: string
+                format: uri
+              instagram:
+                type: string
+                format: uri
+      address:
+        type: object
+        properties:
+          street:
+            type: string
+          city:
+            type: string
+          state:
+            type: string
+          zipCode:
+            type: string
+          country:
+            type: string
+      createdAt:
+        type: string
+        format: date-time
+    required:
+      - id
+      - username
+      - email
+
+  Post:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+      user:
+        type: object
+        properties:
+          id:
+            type: string
+            format: uuid
+          username:
+            type: string
+          profileImage:
+            type: string
+            format: uri
+      content:
+        type: string
+      media:
+        type: object
+        properties:
+          imageUrl:
+            type: string
+            format: uri
+          videoUrl:
+            type: string
+            format: uri
+          mediaType:
+            type: string
+      engagement:
+        type: object
+        properties:
+          likesCount:
+            type: integer
+          commentsCount:
+            type: integer
+          sharesCount:
+            type: integer
+      comments:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            user:
+              type: object
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                username:
+                  type: string
+            content:
+              type: string
+            createdAt:
+              type: string
+              format: date-time
+      createdAt:
+        type: string
+        format: date-time
+    required:
+      - id
+      - content


### PR DESCRIPTION
## Overview

This PR introduces the **OpenAPI Import Feature (Swagger/OpenAPI → Mockify Schema Generation)**, allowing users to upload `.yaml`, `.yml` API specifications directly into a project and automatically generate reusable mock schemas from:

### Supported Sources:

* OpenAPI 3.x (`components.schemas`)
* Swagger 2.0 (`definitions`)

### New User Flow

Previously:

* Login
* Create Organization
* Create Project
* Manually create schemas one-by-one

Now:

* Login
* Create Organization
* Create Project
* Upload OpenAPI/Swagger file or Use can manually create schemas one-by-one  
* Mockify auto-generates schemas + endpoints

---

# Key Features Implemented

## OpenAPI Import Endpoint

### New API:

```http
POST /api/{org}/{project}/import/openapi
Content-Type: multipart/form-data
```

### Supports:

* OpenAPI 3.x
* Swagger 2.0 compatibility
* YAML
* YML
* Nested objects
* Arrays
* URL fields
* Partial schema imports

---

# New Files Added

## Controller

### `OpenApiImportController`

Responsibilities:

* Handles multipart file upload
* Resolves organization/project
* Validates authenticated user
* Delegates import pipeline
* Returns import summary

---

## Services

### `OpenApiParserService + Impl`

Responsibilities:

* Parse raw OpenAPI/Swagger files
* Support YAML/JSON
* Resolve `$ref`
* Detect spec version
* Support OpenAPI 3.x + Swagger 2.0
* Extract reusable schemas
* Normalize parsed result

---

### `OpenApiValidatorService + Impl`

Responsibilities:

* Validate OpenAPI/Swagger version
* Validate reusable schema existence
* Validate schema structure
* Validate primitive + nested fields
* Support Swagger 2.0 validation
* Reject malformed specs

---

### `SchemaExtractorService + Impl`

Responsibilities:

* Convert OpenAPI/Swagger schemas → Mockify schemaJson
* Map formats:

  * uuid
  * email
  * datetime
  * url

### Supports:

* Nested objects
* Arrays
* Empty objects
* Object arrays
* Swagger definitions

---

### `OpenApiImportService + Impl`

Responsibilities:

* File validation
* Missing/empty file rejection
* Max size validation
* Extension validation
* Parse + validate + extract
* Use existing `createSchema()` flow
* Handle partial failures
* Return:

  * imported schemas
  * skipped schemas
  * summary counts

---

# Existing Files Updated

## `MockValidatorServiceImpl`

### Improvements:

### Added support for:

* Nested object validation
* Recursive schema validation
* Recursive record validation
* URL type validation
* Complex arrays
* Object arrays

### New allowed type:

```java
URL("url")
```

### Benefits:

OpenAPI imports now fully support:

* profile objects
* address objects
* cardDetails
* shippingAddress
* website/avatarUrl fields
* enterprise nested schemas

---

## `MockSchemaServiceImpl`

### Updated:

```java
@Transactional(propagation = Propagation.REQUIRES_NEW)
```

### Why:

Each imported schema runs independently.

### Benefit:

If one schema fails:

* others still import successfully
* prevents full rollback
* enterprise-grade partial import support

---

# Error Handling Improvements

## Added:

### `InvalidOpenApiException`

Used for:

* Broken files
* Unsupported formats
* Invalid schemas
* Missing components
* Malformed Swagger/OpenAPI specs

---

# File Validation Rules

Implemented:

* File required
* Empty file rejected
* Max size: 2MB
* Allowed extensions:

  * .yaml
  * .yml

---

# Import Strategy

## Partial Import Supported:

If one schema fails:

```json
{
  "component": "User",
  "reason": "Schema with same name already exists"
}
```

Remaining schemas continue importing.

---

# Test Coverage Added

## 1. `OpenApiImportControllerTest`

### Covered:

* Successful import
* Correct service delegation
* Service exception propagation
* Missing project

---

## 2. `OpenApiImportServiceTest`

### Covered:

* Null file
* Invalid file type
* Oversized file
* Missing project
* Parser failure
* Validator failure
* Partial imports
* Successful imports

---

## 3. `OpenApiParserServiceTest`

### Covered:

* Basic OpenAPI YAML
* Enterprise large specs
* Swagger 2.0 parsing
* Nested schemas
* Arrays
* Invalid files
* Missing schemas

---

## 4. `OpenApiValidatorServiceTest`

### Covered:

*  Valid specs  
* Nested validation
* Arrays
* Missing version
* Invalid Swagger version rejection  
* Invalid schemas

---

## 5. `SchemaExtractorServiceTest`

### Covered:

* Primitive extraction
* UUID/email/datetime/url
* Nested objects
* Arrays
* Object arrays
* `$ref`
* Empty objects

---

## 6. `MockValidatorServiceTest`

### Covered:

* Schema validation
* Record validation
* Nested objects
* Arrays
* URL fields
* UUID
* Email
* Datetime
* Enums
* Invalid fields

---

# Architecture Benefits

## Clean Layer Separation:

### Parser:

Raw file →  OpenAPI spec  

### Validator:

Spec integrity enforcement

### Extractor:

 OpenAPI → Mockify transformation

### Import Service:

Business orchestration

---

# Performance Benefits

* No additional DB tables
* Stateless import process
* Reuses existing schema creation flow
* Minimal disruption
* Supports large enterprise specs

---

# Security

* Existing `SCHEMA:WRITE` permission enforced
* Project scoped
* Multipart validation
* Safe parser validation
* Prevents malformed uploads
* Safe partial imports

---

# Example Result

```json
{
  "totalImported": 7,
  "totalSkipped": 1
}
```

---

# Final Outcome

### Mockify now supports:

## “Upload OpenAPI/Swagger → Auto Build Mock Platform”

This significantly improves:

* Developer onboarding
* Productivity
* Enterprise adoption
* Backward compatibility
* Competitive advantage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * OpenAPI/Swagger file import: upload OpenAPI 3.x and Swagger 2.0 (YAML/JSON) via a multipart request to automatically import mock schemas.

* **Improvements**
  * Enhanced validation and clearer 400 errors for invalid uploads/specs (checks for version, schema structure, and required fields).
  * Improved conversion support for nested objects, arrays, enums, and common formats (UUID, email, datetime, URL).
  * Import results now report totals and support partial imports (imported vs skipped).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->