### PR TITLE
Fix: prevent NPE on startup in production environments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,9 +88,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>io.github.cdimascio</groupId>
-			<artifactId>dotenv-java</artifactId>
-			<version>3.0.0</version>
+			<groupId>me.paulschwarz</groupId>
+			<artifactId>spring-dotenv</artifactId>
+			<version>4.0.0</version>
 		</dependency>
 		<dependency>
           	<groupId>org.projectlombok</groupId>

--- a/src/main/java/com/mockify/backend/MockifyBackendApplication.java
+++ b/src/main/java/com/mockify/backend/MockifyBackendApplication.java
@@ -3,8 +3,6 @@ package com.mockify.backend;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import io.github.cdimascio.dotenv.Dotenv;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.util.TimeZone;
 
@@ -12,36 +10,12 @@ import java.util.TimeZone;
 @SpringBootApplication
 public class MockifyBackendApplication {
 	public static void main(String[] args) {
-		// Load environment variables from .env file at project root
-		// Using ignoreIfMissing() so app won't crash if .env is missing
-		Dotenv dotenv = Dotenv.configure()
-				.ignoreIfMissing()
-				.load();
-
-		// Set DB credentials as system properties for Spring to read in application.properties
-		System.setProperty("DB_URL", dotenv.get("DB_URL"));
-		System.setProperty("DB_USER", dotenv.get("DB_USER"));
-		System.setProperty("DB_PASS", dotenv.get("DB_PASS"));
-
-		// Inject JWT credentials from .env
-		System.setProperty("JWT_SECRET", dotenv.get("JWT_SECRET"));
-		System.setProperty("JWT_ACCESS_EXPIRATION", dotenv.get("JWT_ACCESS_EXPIRATION"));
-		System.setProperty("JWT_REFRESH_EXPIRATION", dotenv.get("JWT_REFRESH_EXPIRATION"));
-
-        // Set Email credentials from .env
-        System.setProperty("MAIL_USERNAME", dotenv.get("MAIL_USERNAME"));
-        System.setProperty("MAIL_PASSWORD", dotenv.get("MAIL_PASSWORD"));
-
 		// Set timezone at JVM level
 		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Kolkata"));
 
-        // Inject Google's OAuth credentials from .env
-		System.setProperty("GOOGLE_CLIENT_ID", dotenv.get("GOOGLE_CLIENT_ID"));
-		System.setProperty("GOOGLE_CLIENT_SECRET", dotenv.get("GOOGLE_CLIENT_SECRET"));
-
 		// Log message to confirm environment variables were loaded successfully
-        log.info("Environment variables loaded");
-        log.info("JVM default timezone set to: {}", TimeZone.getDefault().getID());
+		log.info("Environment variables natively injected by Spring");
+		log.info("JVM default timezone set to: {}", TimeZone.getDefault().getID());
 		SpringApplication.run(MockifyBackendApplication.class, args);
 	}
 }


### PR DESCRIPTION
## Description

This PR fixes a critical `NullPointerException` that was preventing the application from starting in Cloud Run (production). 

**The Issue:** 
Previously, we were manually parsing our `.env` file using `dotenv-java` and pushing the variables into system properties via `System.setProperty()`. Because `.env` files are not deployed to Cloud Run, `dotenv.get()` was returning `null`, which caused `System.setProperty()` to throw an NPE before the Spring Context could even initialize.

**The Solution:**
- Replaced the `dotenv-java` dependency with `spring-dotenv`.
- Removed all manual environment loading boilerplate from `MockifyBackendApplication.java`.
- `spring-dotenv` now seamlessly injects variables into Spring's native `PropertySources`. In environments without a `.env` file (like Cloud Run), the plugin gracefully degrades and allows Spring Boot to natively fall back to OS-level environment variables.

## Changes Made
- **`pom.xml`**: Swapped `io.github.cdimascio:dotenv-java` for `me.paulschwarz:spring-dotenv`.
- **`MockifyBackendApplication.java`**: Cleaned up the `main` method by removing manual `Dotenv` configuration and `System.setProperty()` calls.

## How to Test
1. **Locally:** Start the application as normal with your `.env` file present. Verify that the database connects successfully and that environment variables (e.g., JWT secrets, OAuth credentials) are correctly resolved.
2. **Simulate Production:** Temporarily rename your `.env` file to `.env.backup`, manually export your database environment variables in your terminal session, and start the app. Ensure it starts up without throwing a `NullPointerException`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s environment-variable integration to use Spring-based injection.
  * Simplified application startup by removing manual local `.env` loading and system-property setup.
  * Refreshed startup logging to show the configured timezone and current environment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->