### PR TITLE
Implement Dynamic CORS Origins for Production

### DIFF
--- a/src/main/java/com/mockify/backend/config/SecurityConfig.java
+++ b/src/main/java/com/mockify/backend/config/SecurityConfig.java
@@ -24,6 +24,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import org.springframework.beans.factory.annotation.Value;
 import java.util.Arrays;
 
 /**
@@ -44,6 +45,8 @@ public class SecurityConfig {
     private final ApiKeyAuthenticationFilter apiKeyAuthenticationFilter;
     private final ApiKeyRateLimitFilter apiKeyRateLimitFilter;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    @Value("${app.frontend.url}")
+    private String frontendUrl;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -133,9 +136,14 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
+        // Always allow localhost for local development.
+        // In production, frontendUrl is injected from the FRONTEND_URL env var
+        // (set as a GitHub secret), so no code change is ever needed when
+        // the production frontend URL changes — just update the secret.
         configuration.setAllowedOrigins(Arrays.asList(
                 "http://localhost:3000",
-                "http://localhost:3001"
+                "http://localhost:3001",
+                frontendUrl
         ));
 
         configuration.setAllowedMethods(Arrays.asList(


### PR DESCRIPTION
## Overview
This PR updates our Spring Security configuration to handle Cross-Origin Resource Sharing (CORS) dynamically based on the environment, allowing our deployed frontend (e.g. Netlify) to successfully communicate with the Cloud Run backend.

## Key Changes
* **Dynamic Origin Injection:** Replaced the hardcoded localhost URLs in `SecurityConfig.java` with a dynamically injected `${app.frontend.url}` property.
* **Environment Variable Support:** This property maps to the `FRONTEND_URL` environment variable, which is securely injected via GitHub Secrets at deployment time.

## Why this matters
By externalizing the CORS allowed origins into a GitHub Secret, we can now update or change our frontend hosting URL (e.g., mapping a custom domain) purely through environment variables. **Zero code changes or new commits will be required** when the frontend URL changes in the future.

## Testing / Verification
- [x] Verified `http://localhost:3000` and `http://localhost:3001` remain allowed for local development.
- [x] Verified `FRONTEND_URL` secret in GitHub is set to `https://mockifyapp.netlify.app`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-origin access for the production frontend while preserving local development access.
  * Added configurable frontend origin support for more reliable production connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->