### PR TITLE
feat(asset): implement asset upload API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,12 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>3.2.1</version>
+        </dependency>
+
     </dependencies>
 
 	<build>

--- a/src/main/java/com/mockify/backend/config/TikaConfig.java
+++ b/src/main/java/com/mockify/backend/config/TikaConfig.java
@@ -1,0 +1,14 @@
+package com.mockify.backend.config;
+
+import org.apache.tika.Tika;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TikaConfig {
+
+    @Bean
+    public Tika tika(){
+        return new Tika();
+    }
+}

--- a/src/main/java/com/mockify/backend/constants/AssetConstants.java
+++ b/src/main/java/com/mockify/backend/constants/AssetConstants.java
@@ -1,0 +1,12 @@
+package com.mockify.backend.constants;
+
+public class AssetConstants {
+
+    private AssetConstants() {}
+
+    public static final String SAMPLE_IMAGE_URL =
+            "https://picsum.photos/800/600";
+
+    public static final String SAMPLE_FILE_URL =
+            "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf";
+}

--- a/src/main/java/com/mockify/backend/controller/AssetController.java
+++ b/src/main/java/com/mockify/backend/controller/AssetController.java
@@ -1,0 +1,31 @@
+package com.mockify.backend.controller;
+
+import com.mockify.backend.dto.response.Asset.UploadResponse;
+import com.mockify.backend.service.AssetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("api/assets")
+@RequiredArgsConstructor
+public class AssetController {
+
+    private final AssetService assetService;
+
+    @PostMapping(
+            value = "/upload",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+
+    )
+    public ResponseEntity<UploadResponse> upload(
+            @RequestParam("file") MultipartFile file
+            ){
+        return ResponseEntity.ok(assetService.upload(file));
+    }
+}

--- a/src/main/java/com/mockify/backend/dto/response/Asset/UploadResponse.java
+++ b/src/main/java/com/mockify/backend/dto/response/Asset/UploadResponse.java
@@ -1,0 +1,20 @@
+package com.mockify.backend.dto.response.Asset;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UploadResponse {
+
+    private boolean success;
+
+    private String message;
+
+    private String assetType;
+
+    private String url;
+
+}

--- a/src/main/java/com/mockify/backend/exception/InvalidAssetException.java
+++ b/src/main/java/com/mockify/backend/exception/InvalidAssetException.java
@@ -1,0 +1,7 @@
+package com.mockify.backend.exception;
+
+public class InvalidAssetException extends RuntimeException{
+    public InvalidAssetException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/mockify/backend/fileValidator/FileValidator.java
+++ b/src/main/java/com/mockify/backend/fileValidator/FileValidator.java
@@ -1,0 +1,79 @@
+package com.mockify.backend.fileValidator;
+
+import com.mockify.backend.exception.InvalidAssetException;
+import lombok.RequiredArgsConstructor;
+import org.apache.tika.Tika;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class FileValidator {
+
+    private static final long MAX_SIZE = 10 * 1024 * 1024;
+
+    private static final Set<String> IMAGE_TYPES = Set.of(
+            "image/png",
+            "image/jpeg",
+            "image/jpg",
+            "image/webp",
+            "image/gif",
+            "image/svg+xml",
+            "image/bmp"
+    );
+
+    private static final Set<String> FILE_TYPES = Set.of(
+            "application/pdf",
+            "text/plain",
+            "text/csv",
+            "application/msword",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.ms-excel",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.ms-powerpoint",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "application/zip",
+            "application/json",
+            "application/xml"
+    );
+
+    private final Tika tika;
+
+
+
+    public String validate(MultipartFile file) {
+
+        if (file == null || file.isEmpty()) {
+            throw new InvalidAssetException("File is empty.");
+        }
+
+        if (file.getSize() > MAX_SIZE) {
+            throw new InvalidAssetException("Maximum file size is 10 MB.");
+        }
+
+       try{
+           String detectedType =tika.detect(file.getInputStream());
+
+           if(!IMAGE_TYPES.contains(detectedType)
+           && !FILE_TYPES.contains(detectedType)){
+               throw new InvalidAssetException(
+                       "Unsupported file type: " +detectedType
+               );
+           }
+
+           return detectedType;
+       }catch (IOException e){
+           throw new InvalidAssetException("Unable to inspect uploaded file.");
+       }
+    }
+
+    public boolean isImage(String mimeType) {
+
+        return IMAGE_TYPES.contains(mimeType);
+
+    }
+
+}

--- a/src/main/java/com/mockify/backend/service/AssetService.java
+++ b/src/main/java/com/mockify/backend/service/AssetService.java
@@ -1,0 +1,9 @@
+package com.mockify.backend.service;
+
+import com.mockify.backend.dto.response.Asset.UploadResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface AssetService {
+
+    UploadResponse upload(MultipartFile file);
+}

--- a/src/main/java/com/mockify/backend/service/impl/AssetServiceImpl.java
+++ b/src/main/java/com/mockify/backend/service/impl/AssetServiceImpl.java
@@ -1,0 +1,38 @@
+package com.mockify.backend.service.impl;
+
+import com.mockify.backend.fileValidator.FileValidator;
+import com.mockify.backend.constants.AssetConstants;
+import com.mockify.backend.dto.response.Asset.UploadResponse;
+import com.mockify.backend.service.AssetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class AssetServiceImpl implements AssetService {
+
+    private final FileValidator fileValidator;
+
+    @Override
+    public UploadResponse upload(MultipartFile file) {
+
+         String mimeType = fileValidator.validate(file);
+
+        if (fileValidator.isImage(mimeType)) {
+            return new UploadResponse(
+                    true,
+                    "Image uploaded successfully.",
+                    "IMAGE",
+                    AssetConstants.SAMPLE_IMAGE_URL
+            );
+        }
+
+        return new UploadResponse(
+                true,
+                "File uploaded successfully.",
+                "FILE",
+                AssetConstants.SAMPLE_FILE_URL
+        );
+    }
+}

--- a/src/test/java/com/mockify/backend/controller/AssetControllerTest.java
+++ b/src/test/java/com/mockify/backend/controller/AssetControllerTest.java
@@ -1,0 +1,94 @@
+package com.mockify.backend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mockify.backend.dto.response.Asset.UploadResponse;
+import com.mockify.backend.service.AssetService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class AssetControllerTest {
+
+    @Mock
+    private AssetService assetService;
+
+    @InjectMocks
+    private AssetController assetController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(assetController)
+                .build();
+    }
+
+    @Test
+    void shouldUploadImageSuccessfully() throws Exception {
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "image.png",
+                MediaType.IMAGE_PNG_VALUE,
+                "dummy".getBytes()
+        );
+
+        UploadResponse response = new UploadResponse(
+                true,
+                "Image uploaded successfully.",
+                "IMAGE",
+                "https://example.com/image.png"
+        );
+
+        when(assetService.upload(file)).thenReturn(response);
+
+        mockMvc.perform(multipart("/api/assets/upload")
+                        .file(file))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("Image uploaded successfully."))
+                .andExpect(jsonPath("$.assetType").value("IMAGE"))
+                .andExpect(jsonPath("$.url").value("https://example.com/image.png"));
+    }
+
+    @Test
+    void shouldUploadFileSuccessfully() throws Exception {
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "sample.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                "dummy".getBytes()
+        );
+
+        UploadResponse response = new UploadResponse(
+                true,
+                "File uploaded successfully.",
+                "FILE",
+                "https://example.com/file.pdf"
+        );
+
+        when(assetService.upload(file)).thenReturn(response);
+
+        mockMvc.perform(multipart("/api/assets/upload")
+                        .file(file))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("File uploaded successfully."))
+                .andExpect(jsonPath("$.assetType").value("FILE"))
+                .andExpect(jsonPath("$.url").value("https://example.com/file.pdf"));
+    }
+}

--- a/src/test/java/com/mockify/backend/fileValidator/FileValidatorTest.java
+++ b/src/test/java/com/mockify/backend/fileValidator/FileValidatorTest.java
@@ -1,0 +1,175 @@
+package com.mockify.backend.fileValidator;
+
+import com.mockify.backend.exception.InvalidAssetException;
+import org.apache.tika.Tika;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FileValidatorTest {
+
+    @Mock
+    private Tika tika;
+
+    @InjectMocks
+    private FileValidator fileValidator;
+
+    @Test
+    void shouldReturnMimeTypeWhenValidImageIsUploaded() throws IOException {
+        // Arrange
+        MultipartFile file = new MockMultipartFile(
+                "file",
+                "image.png",
+                "image/png",
+                "dummy".getBytes()
+        );
+
+        when(tika.detect(any(InputStream.class))).thenReturn("image/png");
+
+        // Act
+        String mimeType = fileValidator.validate(file);
+
+        // Assert
+        assertEquals("image/png", mimeType);
+    }
+
+    @Test
+    void shouldReturnMimeTypeWhenValidPdfIsUploaded() throws IOException {
+        // Arrange
+        MultipartFile file = new MockMultipartFile(
+                "file",
+                "sample.pdf",
+                "application/pdf",
+                "dummy".getBytes()
+        );
+
+        when(tika.detect(any(InputStream.class))).thenReturn("application/pdf");
+
+        // Act
+        String mimeType = fileValidator.validate(file);
+
+        // Assert
+        assertEquals("application/pdf", mimeType);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenFileIsNull() {
+
+        InvalidAssetException exception = assertThrows(
+                InvalidAssetException.class,
+                () -> fileValidator.validate(null)
+        );
+
+        assertEquals("File is empty.", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenFileIsEmpty() {
+
+        MultipartFile file = new MockMultipartFile(
+                "file",
+                "",
+                "application/pdf",
+                new byte[0]
+        );
+
+        InvalidAssetException exception = assertThrows(
+                InvalidAssetException.class,
+                () -> fileValidator.validate(file)
+        );
+
+        assertEquals("File is empty.", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenFileSizeExceedsTenMB() {
+
+        byte[] largeContent = new byte[10 * 1024 * 1024 + 1];
+
+        MultipartFile file = new MockMultipartFile(
+                "file",
+                "large.pdf",
+                "application/pdf",
+                largeContent
+        );
+
+        InvalidAssetException exception = assertThrows(
+                InvalidAssetException.class,
+                () -> fileValidator.validate(file)
+        );
+
+        assertEquals("Maximum file size is 10 MB.", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUnsupportedFileTypeIsUploaded() throws IOException {
+
+        MultipartFile file = new MockMultipartFile(
+                "file",
+                "program.exe",
+                "application/octet-stream",
+                "dummy".getBytes()
+        );
+
+        when(tika.detect(any(InputStream.class)))
+                .thenReturn("application/octet-stream");
+
+        InvalidAssetException exception = assertThrows(
+                InvalidAssetException.class,
+                () -> fileValidator.validate(file)
+        );
+
+        assertEquals(
+                "Unsupported file type: application/octet-stream",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTikaThrowsIOException() throws IOException {
+
+        MultipartFile file = new MockMultipartFile(
+                "file",
+                "sample.pdf",
+                "application/pdf",
+                "dummy".getBytes()
+        );
+
+        when(tika.detect(any(InputStream.class)))
+                .thenThrow(new IOException("Read error"));
+
+        InvalidAssetException exception = assertThrows(
+                InvalidAssetException.class,
+                () -> fileValidator.validate(file)
+        );
+
+        assertEquals(
+                "Unable to inspect uploaded file.",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldReturnTrueWhenMimeTypeIsImage() {
+
+        assertTrue(fileValidator.isImage("image/png"));
+    }
+
+    @Test
+    void shouldReturnFalseWhenMimeTypeIsNotImage() {
+
+        assertFalse(fileValidator.isImage("application/pdf"));
+    }
+}

--- a/src/test/java/com/mockify/backend/service/AssetServiceTest.java
+++ b/src/test/java/com/mockify/backend/service/AssetServiceTest.java
@@ -1,0 +1,82 @@
+package com.mockify.backend.service;
+
+import com.mockify.backend.fileValidator.FileValidator;
+import com.mockify.backend.constants.AssetConstants;
+import com.mockify.backend.dto.response.Asset.UploadResponse;
+import com.mockify.backend.service.impl.AssetServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AssetServiceTest {
+
+    @Mock
+    private FileValidator fileValidator;
+
+    @InjectMocks
+    private AssetServiceImpl assetService;
+
+    @Test
+    void shouldReturnImageUploadResponseWhenUploadedFileIsImage() {
+        // Arrange
+        MultipartFile file = new MockMultipartFile(
+                "file",
+                "image.png",
+                "image/png",
+                "dummy-image".getBytes()
+        );
+
+        when(fileValidator.validate(file)).thenReturn("image/png");
+        when(fileValidator.isImage("image/png")).thenReturn(true);
+
+        // Act
+        UploadResponse response = assetService.upload(file);
+
+        // Assert
+        assertNotNull(response);
+        assertTrue(response.isSuccess());
+        assertEquals("Image uploaded successfully.", response.getMessage());
+        assertEquals("IMAGE", response.getAssetType());
+        assertEquals(AssetConstants.SAMPLE_IMAGE_URL, response.getUrl());
+
+        verify(fileValidator).validate(file);
+        verify(fileValidator).isImage("image/png");
+        verifyNoMoreInteractions(fileValidator);
+    }
+
+    @Test
+    void shouldReturnFileUploadResponseWhenUploadedFileIsNotImage() {
+        // Arrange
+        MultipartFile file = new MockMultipartFile(
+                "file",
+                "document.pdf",
+                "application/pdf",
+                "dummy-pdf".getBytes()
+        );
+
+        when(fileValidator.validate(file)).thenReturn("application/pdf");
+        when(fileValidator.isImage("application/pdf")).thenReturn(false);
+
+        // Act
+        UploadResponse response = assetService.upload(file);
+
+        // Assert
+        assertNotNull(response);
+        assertTrue(response.isSuccess());
+        assertEquals("File uploaded successfully.", response.getMessage());
+        assertEquals("FILE", response.getAssetType());
+        assertEquals(AssetConstants.SAMPLE_FILE_URL, response.getUrl());
+
+        verify(fileValidator).validate(file);
+        verify(fileValidator).isImage("application/pdf");
+        verifyNoMoreInteractions(fileValidator);
+    }
+}


### PR DESCRIPTION
## Summary

Implemented the asset upload feature with validation and mock upload responses.

### Changes

- Added `AssetController` to handle asset upload requests.
- Implemented `AssetService` and `AssetServiceImpl` for upload processing.
- Added `UploadResponse` DTO for upload responses.
- Added `AssetConstants` for mock asset URLs.
- Implemented `FileValidator` to:
  - Validate empty files.
  - Enforce a 10 MB file size limit.
  - Detect MIME types using Apache Tika.
  - Validate supported image and document types.
  - Identify image uploads.
- Added `TikaConfig` to register Apache Tika as a Spring Bean.
- Refactored `FileValidator` to use constructor-based dependency injection for `Tika`.

## Testing

## Testing

- ✅ Verified `AssetServiceImpl` with unit tests.
- ✅ Verified `FileValidator` with unit tests.
- ✅ All `FileValidator` tests passing (9 tests, 0 failures).
- 
## Validation

- Rejects empty files.
- Rejects files larger than 10 MB.
- Accepts supported image and document types.
- Detects the actual MIME type using Apache Tika.
- Returns mock asset URLs based on the uploaded file type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file upload support through a new API endpoint.
  * Added validation for empty files, unsupported formats, and files over 10 MB.
  * Upload responses now identify the asset type and provide a corresponding URL.
  * Added support for detecting image and document file types.

* **Bug Fixes**
  * Invalid uploads now return clear validation errors instead of being processed.

* **Tests**
  * Added coverage for upload responses, file validation, supported formats, size limits, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->